### PR TITLE
.gitignore mistakenly ignores inc/Perl/Critic/Module/Build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Build
+/Build
 Debian_CPANTS.txt
 MANIFEST.bak
 META.json


### PR DESCRIPTION
.gitignore references "Build", which causes git to ignore "Build" but also "inc/Perl/Critic/Module/Build/" since it is not anchored on the left.

The attached commit fixes that, thank you for considering it!
