### PR TITLE
update invalid profile test to match change in Config::Tiny 2.17

### DIFF
--- a/t/10_user_profile.t
+++ b/t/10_user_profile.t
@@ -294,7 +294,7 @@ END_PROFILE
     eval { Perl::Critic::UserProfile->new( -profile => 'bogus' ) };
     like(
         $EVAL_ERROR,
-        qr/File [ ] 'bogus' [ ] does [ ] not [ ] exist/xms,
+        qr/Failed [ ] to [ ] open [ ] file [ ] 'bogus' [ ] for [ ] reading: [ ]/xms,
         'Invalid profile path',
     );
 


### PR DESCRIPTION
Config::Tiny 2.17 was released to CPAN about 12 hours ago.  [ RT#36974](https://rt.cpan.org/Public/Bug/Display.html?id=36974) changed the error messages returned by Config::Tiny->read, breaking this test.
