### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,26 +1,26 @@
-[1.120_01] Released on 2013-10-29
+Revision history for Perl module Perl::Critic
 
-      * DEVELOPER RELEASE *
+1.120_01 2013-10-29 *DEVELOPER RELEASE*
 
-      Added new themes based on CERT guidelines. Thanks Kirk Kimmel.
+      * Added new themes based on CERT guidelines. Thanks Kirk Kimmel.
+      * First release from the new GitHub repository.
 
-      First release from the new GitHub repository.
 
-[1.120] Released on 2013-10-25
+1.120 2013-10-25
 
-     Bug Fixes:
+     [Bug Fixes]
      * Corrected "Possible precedence issue with control flow operator" 
        warning.  This fixes RT #88866
 
-[1.119] Released on 2013-09-25
 
-     Bug Fixes:
+1.119 2013-09-25
+
+     [Bug Fixes]
      * Tests were failing with Config::Tiny 2.17 or later, due to a
        change in the error messages produced by that module. 
        This fixes #16 on Github,  #88679 & #88889 on RT.
 
-
-     Policy Changes:
+     [Policy Changes]
      * BuiltinFunctions::ProhibitVoidGrep and ::ProhibitVoidMap: grep
        and map called as functions are now allowed in slice operations.
        RT #79289
@@ -28,13 +28,14 @@
      * Subroutines::RequireArgUnpacking: Most tests of the size of @_
        are now allowed.  RT #79138
 
-     Other Changes:
+     [Other Changes]
      * Modernized our usage of Exporter.  See RT #75300.  
        Thanks to Olivier Mengué for the patch.
 
-[1.118] Released on 2012-07-10
 
-    Policy Changes:
+1.118 2012-07-10
+
+    [Policy Changes]
     * CodeLayout::RequireTidyCode: Revise to work with incompatible
       changes in Perl::Tidy 20120619. RT #77977.
     * TestingAndDebugging::ProhibitNoWarnings: Correct the parse of the
@@ -43,20 +44,19 @@
     * Miscellanea::RequireRcsKeywords has been moved to the Perl-Critic-More
       distribution,  RT #69546
 
-    Other Changes:
+    [Other Changes]
     * Make all unescaped literal "{" characters in regexps into
       character classes. These are deprecated, and became noisy with
       Perl 5.17.0.  RT #77510.
 
-[1.117] Released on 2011-12-21
 
-    HAPPY HOLIDAYS!
+1.117 2011-12-21 HAPPY HOLIDAYS!
 
-    New Policies:
+    [New Policies]
     * Variables::ProhibitAugmentedAssignmentInDeclaration reports
       constructs like 'my $x += 1'. Contributed by Mike O'Regan
 
-    Policy Changes:
+    [Policy Changes]
     * BuiltinFunctions::ProhibitLvalueSubstr: Add explicit 'use version'.
       RT #68498.
     * CodeLayout::ProhibitHardTabs: Add 'pbp' to the default_themes list.
@@ -88,15 +88,17 @@
       variables embedded in interpolated strings (e.g. "${$}"). For the
       purpose of the 'allow' configuration, these are considered
       equivalent to the unbracketed form. RT #72910.
-    Other Changes:
+
+    [Other Changes]
     * Corrected POD in Perl::Critic::PPI::Utils. RT #68898.
     * Perl::Critic::Violation source() method now returns the line
       containing the violation (not the first line) when the statement
       containing the violation spans multiple lines.
 
-[1.116] Released on 2011-05-15
 
-    Policy Changes:
+1.116 2011-05-15
+
+    [Policy Changes]
     * BuiltInFunctions::ProhibitLvalueSubstr does not report violations
       if the document contains an explicit 'use n.nnn;' where the
       version is before 5.005.  RT #59112
@@ -113,17 +115,19 @@
       if the document contains an explicit 'use n.nnn;' where the
       version is before 5.004.  RT #67760
 
-[1.115] Released on 2011-03-31
 
-    Minor bits:
+1.115 2011-03-31
+
+    [Minor Changes]
     * Fatal error in RegularExpressions::ProhibitUnusedCapture here
       document check.  RT #67116.
     * Internal POD error in Documentation::RequirePodLinksIncludeText.  Patch
       by Salvatore Bonaccorso.  RT #67012
 
-[1.114] Released on 2011-03-26
 
-    Policy Changes:
+1.114 2011-03-26
+
+    [Policy Changes]
     * Documentation::RequirePodLinksIncludeText now handles nested POD
       formatting. RT #65569
     * Clarified relation of severity numbers to names in Perl::Critic
@@ -148,9 +152,10 @@
       recognizes 'bless { foo => 1, bar => 2 }' as containing a hash
       constructor, not a block. This was fixed by PPI 1.215. RT #64132.
 
-[1.113] Released on 2011-02-14
 
-    New Policies:
+1.113 2011-02-14
+
+    [New Policies]
     * InputOutput::RequireEncodingWithUTF8Layer recommends
       ':encoding(utf8)' over ':utf8' in open() and binmode(). It is severity 5
       because of the bad things that can happen if invalid UTF8 gets loose in
@@ -160,7 +165,7 @@
       unconditionally at compile time.  Thanks to Peter Guzis for submitting
       the policy and tests in RT #59065.
 
-    Policy Changes:
+    [Policy Changes]
     * CodeLayout::RequireConsistentNewlines produces multiple undefined
       value errors when a violation is found. RT #65663
     * ControlStructures::ProhibitMutatingListFunctions allows s///r,
@@ -192,14 +197,14 @@
       "\1" through "\7", which are not documented there, but were found
       in toke.c.
 
-    New Developer Features:
+    [New Developer Features]
     * uses_module(), namespaces(), and subdocuments_for_namespace() methods on
       Perl::Critic::Document.
     * Perl::Critic::Document->new() now accepts a -filename-override argument
       for setting the filename when the source code comes from something
       other than an actual file.
 
-    Other Changes:
+    [Other Changes]
     * Test::Perl::Critic::Policy no longer exports by default.
     * Build phase now requires Test::Deep.
     * Added example using Try::Tiny to documentation of
@@ -211,7 +216,7 @@
       prerequisites.
     * Now depends upon PPIx::Utilities v1.1.0.
 
-    Bug Fixes:
+    [Bug Fixes]
     * Build.PL/Makefile.PL didn't specify a minimum version of version.pm, but
       TestingAndDebugging::RequireUseStrict did.  RT #58952
     * Perl::Critic::Annotation needs to look inside the __END__ statement to
@@ -230,41 +235,47 @@
     * Subroutines::ProhibitAmpersandSigils now allows references of the
       form \( &sub1, &sub2 ).  RT #49609
 
-[1.112_002] Released on 2011-02-09
-[1.112_001] Released on 2010-12-14
+1.112_002 2011-02-09
+1.112_001 2010-12-14
 
-    Changes summarized into 1.113 above.  For exact details, see Changes on
-    BackPAN.
+    * Changes summarized into 1.113 above.
+      For exact details, see Changes on BackPAN.
 
-[1.111] Released on 2010-12-14
 
-    Bug Fixes:
+1.111 2010-12-14
+
+    [Bug Fixes]
     * TestingAndDebugging::ProhibitNoStrict and ProhibitNoWarnings no longer
       rely on the behavior of all() when the list is empty due to change in
       List::MoreUtils 0.28.  RT #63816
 
-[1.110_001] Released on 2010-11-30
 
-    Changes summarized into 1.113 above.  For exact details, see Changes on
-    BackPAN.  (Yes, all of this stuff was not in 1.111.)
+1.110_001 2010-11-30
 
-[1.109] Released on 2010-08-29
+    * Changes summarized into 1.113 above.
+      For exact details, see Changes on BackPAN.
+      (Yes, all of this stuff was not in 1.111.)
 
-    Bug Fixes:
+
+1.109 2010-08-29
+
+    [Bug Fixes]
     * ValuesAndExpressions::RequireInterpolationOfMetachars fix due to changes
       in Email::Address 1.890.  Note that this may find problems in code that
       it didn't before, e.g. q<'@foo'>.
 
-[1.108] Released on 2010-06-22
 
-    This is the "Give Shawn Moore what we promised him a year ago and hurry up
-    and get this out before Brad Oaks gives his YAPC::NA talk" release.
+1.108 2010-06-22
 
-    New Policies:
+    [Dedication]
+    * This is the "Give Shawn Moore what we promised him a year ago and hurry
+      up and get this out before Brad Oaks gives his YAPC::NA talk" release.
+
+    [New Policies]
     * Documentation::RequirePodLinksIncludeText
     * Subroutines::ProhibitUnusedPrivateSubroutines
 
-    New Features:
+    [New Features]
     * There is a new global configuration item, 'program-extensions', which
       configures Perl::Critic's idea of which file name extensions represent
       programs.  The desired extensions are specified as a space-separated list,
@@ -283,7 +294,7 @@
       Policies.  See Test::Perl::Critic::Policy and Perl::Critic::TestUtils
       for details.
 
-    Policy Changes
+    [Policy Changes]
     * BuiltInFunctions::ProhibitLvalueSubstr no longer complains when there
       is a low-precedence operator between the substr() and the assignment
       operator.
@@ -319,7 +330,7 @@
     * Variables::ProhibitPunctuationVars gave false positives on qr// regexp's
       ending in '$'.  RT #55604
 
-    Bug Fixes:
+    [Bug Fixes]
     * The "## no critic" annotations now respect #line directives.
     * Annotations on statements spanning more than one line (e.g.
             my $foo =
@@ -342,7 +353,7 @@
     * Perldoc hae broken link for McCabe score definition.  RT #53219
     * RT #33935 and #49679 were fixed by upgrading to PPI 1.208
 
-    Other Changes:
+    [Other Changes]
     * Perl::Critic::Utils::is_unchecked_call() updated to include chmod in the
       set of things covered by autodie (this happened in autodie v2.08).  The
       primary effect of this is on InputOutput::RequireCheckedSyscalls.
@@ -368,51 +379,57 @@
       will be available on http://search.cpan.org.  Thanks to Bear Longyear
       for bringing this to our attention.
 
-[1.107_001] Released on 2010-06-20
 
-    Changes summarized into 1.108 above.  For exact details, see Changes on
-    BackPAN.
+1.107_001 2010-06-20
 
-[1.106] Released on 2010-05-10
+    * Changes summarized into 1.108 above.
+      For exact details, see Changes on BackPAN.
 
-    Bug Fixes:
+
+1.106 2010-05-10
+
+    [Bug Fixes]
     * NamingConventions::Capitalization fix for PPI 1.212.  RT #57348
 
-[1.105_03] Released on 2010-03-21
-[1.105_02] Released on 2010-01-23
-[1.105_01] Released on 2010-01-16
 
-    Changes summarized into 1.108 above.  For exact details, see Changes on
-    BackPAN.
+1.105_03 2010-03-21
+1.105_02 2010-01-23
+1.105_01 2010-01-16
 
-[1.105] Released on 2009-09-07
+    * Changes summarized into 1.108 above.
+      For exact details, see Changes on BackPAN.
 
-    Bug Fixes:
+
+1.105 2009-09-07
+
+    [Bug Fixes]
     * Variables::ProhibitPunctuationVars would complain about "%-" appearing
       anywhere in a string.  RT #49016
 
-    Policy Changes:
+    [Policy Changes]
     * InputOutput::RequireCheckedSyscalls now complains about unchecked "say"
       by default.  RT #37487
 
-[1.104] Released on 2009-08-23
 
-    This release is dedicated to Tom Wyant in appreciation of the amount of
-    effort he put into the enhancements and bug fixes in this release, for
-    having the patience to wait for the amount of time that it took to get
-    them out, and for overall awesomeness.  Thank you, Tom.
+1.104 2009-08-23
 
-    New Policies:
-      Objects::ProhibitIndirectSyntax
-      ValuesAndExpressions::ProhibitComplexVersion
-      ValuesAndExpressions::RequireConstantVersion
+    [Dedication]
+    * This release is dedicated to Tom Wyant in appreciation of the amount of
+      effort he put into the enhancements and bug fixes in this release, for
+      having the patience to wait for the amount of time that it took to get
+      them out, and for overall awesomeness.  Thank you, Tom.
 
-    New Optional Requirement:
+    [New Policies]
+    * Objects::ProhibitIndirectSyntax
+    * ValuesAndExpressions::ProhibitComplexVersion
+    * ValuesAndExpressions::RequireConstantVersion
+
+    [New Optional Requirement]
     * Email::Address, if you want
       ValuesAndExpressions::ProhibitInterpolationOfLiterals to properly ignore
       email addresses.
 
-    New Features:
+    [New Features]
     * Perlcritic will list the names of files with violations if given the
       --files-with-violations option, or the names of files without
       violations if given the --files-without-violations options. These
@@ -427,7 +444,7 @@
       %F, %f, and %l formats.  You can get the old values via the new %G, %g,
       and %L formats.
 
-    Policy Changes:
+    [Policy Changes]
     * CodeLayout::ProhibitParensWithBuiltins was complaining in certain cases
       where parentheses are required due to operator precedence.  RT #46862.
     * ControlStructures::ProhibitMutatingListFunctions no longer complains
@@ -465,75 +482,80 @@
     * Variables::ProhibitPunctuationVars now ignores $] by default since there
       is no English.pm equivalent.
 
-    Other Bug Fixes:
+    [Other Bug Fixes]
     * Perl::Critic::Utils::parse_arg_list() was slurping up the "or die ..."
       portion of "open my $foo, 'somefile' or die ...", causing
       InputOutput::ProhibitTwoArgOpen to not complain about this example.
       Reported by Alexandr Ciornii,  RT #44554.
 
-    Minor Changes
+    [Minor Changes]
     * The line count emitted by the --statistics option is further broken down
       by line content.
 
-    Minor Documentation Fixes:
+    [Minor Documentation Fixes]
     * ValuesAndExpressions::ProhibitInterpolationOfLiterals.  Reported by
       Debian in http://bugs.debian.org/542814,  RT #48936
 
-    Build Fixes:
+    [Build Fixes]
     * There wasn't a specific version given for the List::MoreUtils dependency
       and we're using features that weren't avialable until 0.19.  So, we now
       require version 0.19.  Noticed by John J. Trammell,  RT #48917.
     * Some tests were tied to the specific "true" and "false" values that some
       functions were returning.  Reported by Michael Schwern,  RT #43910.
 
-    Other News:
+    [Other News]
     * Komodo version 5.1.1 now has built-in support for Perl-Critic,
       if you have the Perl::Critic and criticism modules installed.
       Both should be available through the ActiveState Perl Package
       Manager ppm(1).
 
-[1.103] Released on 2009-08-03
 
-    Fix configure_requires prerequisite on Module::Build 0.34_02.
+1.103 2009-08-03
 
-[1.102] Released on 2009-08-03
+    * Fix configure_requires prerequisite on Module::Build 0.34_02.
 
-    Bug fixes:
+
+1.102 2009-08-03
+
+    [Bug Fixes]
     * Works with PPI 1.205.  Yay for 5.10 support!
     * Variables::RequireLexicalLoopIterators didn't work correctly on foreach
       loops with labels.
 
-[1.101_003] Released on 2009-07-22
-[1.101_002] Released on 2009-07-21
-[1.101_001] Released on 2009-07-21
 
-    Changes summarized into 1.102 above.  For exact details, see Changes on
-    BackPAN.
+1.101_003 2009-07-22
+1.101_002 2009-07-21
+1.101_001 2009-07-21
 
-[1.100] Released on 2009-07-17
+    * Changes summarized into 1.102 above.
+      For exact details, see Changes on BackPAN.
 
-    This is a POD fix release to deal with issues identified by Test::POD
-    1.40.  There is no functional difference between this release and 1.098.
-    This is the last release of Perl::Critic that will be compatible with PPI
-    1.203.  PPI's parsing of for(each)? loops is changing in its next release
-    in an incompatible manner and there will be a release in the near future
-    to make Perl::Critic compatible with that change.
 
-[1.099_002] Released on 2009-06-27
-[1.099_001] Released on 2009-06-25
+1.100 2009-07-17
 
-    Experimental releases.  For exact details, see Changes on BackPAN.
+    * This is a POD fix release to deal with issues identified by Test::POD
+      1.40.  There is no functional difference between this release and 1.098.
+      This is the last release of Perl::Critic that will be compatible with PPI
+      1.203.  PPI's parsing of for(each)? loops is changing in its next release
+      in an incompatible manner and there will be a release in the near future
+      to make Perl::Critic compatible with that change.
 
-[1.098] Released on 2009-03-07
 
-    Some Exciting News:
-    The Perl Development Kit (PDK 8.0) from ActiveState now includes a
-    very slick graphical interface to Perl-Critic.  I highly recommend
-    that you check it out.  Here's a link to screenshots and docs:
+1.099_002 2009-06-27
+1.099_001 2009-06-25
 
-    http://docs.activestate.com/pdk/8.0/PerlCritic_gui.html
+    * Experimental releases.  For exact details, see Changes on BackPAN.
 
-    New Features:
+
+1.098 2009-03-07
+
+    [Some Exciting News]
+    * The Perl Development Kit (PDK 8.0) from ActiveState now includes a
+      very slick graphical interface to Perl-Critic.  I highly recommend
+      that you check it out.  Here's a link to screenshots and docs:
+      http://docs.activestate.com/pdk/8.0/PerlCritic_gui.html
+
+    [New Features]
     * Violation coloring is now configurable via command line or profile. The
       profile entries are color-severity-highest, -high, -medium, -low, or
       -lowest. Numbers are accepted in lieu of named severities (e.g.
@@ -546,7 +568,7 @@
     * The --verbose option for perlcritic now supports a %C format that will
       displays the class of PPI::Element that caused the violation.
 
-    Policy Changes:
+    [Policy Changes]
     * ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
       didn't include "pbp" in its default themes even though it is derived
       from the book.  Now it does.  :]
@@ -580,7 +602,7 @@
     * Variables::RequireLocalizedPunctuationVars has a customizable set of
       exemptions via the "allow" option.
 
-    New Developer Features:
+    [New Developer Features]
     * The guts of perlcritic have been moved to Perl::Critic::Command.  You
       can invoke Perl::Critic::Command::run() to get the equivalent of running
       the command.  (Note, however, this interface WILL change, so don't count
@@ -593,7 +615,7 @@
     * P::C::Policy now has an is_enabled() method.
     * P::C::Violation now has an element_class() method.
 
-    Bug Fixes:
+    [Bug Fixes]
     * CodeLayout::ProhibitTrailingWhitespace didn't notice cases where PPI
       would produce instances of PPI::Token::Whitespace that contained
       multiple lines.
@@ -604,25 +626,27 @@
     * Variables::RequireLocalizedPunctuationVars now applies to subscripted
       names.  RT #29384.
 
-    Internals:
+    [Internals]
     * The guts of Build.PL and Makefile.PL have been rearranged.
 
-[1.097_002] Released on 2009-03-01
-[1.097_001] Released on 2009-03-01
 
-    Changes summarized into 1.098 above.  For exact details, see Changes on
-    BackPAN.
+1.097_002 2009-03-01
+1.097_001 2009-03-01
 
-[1.096] Released on 2009-02-01
+    * Changes summarized into 1.098 above.
+      For exact details, see Changes on BackPAN.
 
-    New Policies:
+
+1.096 2009-02-01
+
+    [New Policies]
     * ValuesAndExpressions::ProhibitSpecialLiteralHeredocTerminator
 
-    Policy Changes:
+    [Policy Changes]
     * Documentation::PodSpelling now has a stop_words_file option.
     * Modules::ProhibitEvilModules now has a modules_file option.
 
-    Bug Fixes:
+    [Bug Fixes]
     * ErrorHandling::RequireCarping will now allow a literal newline
       as well as "\n".  Fixed by Kyle Hasselbacher, RT #25046
     * Fix InputOutput::ProhibitTwoArgOpen so it allows '-|' or '|-' as the
@@ -646,22 +670,26 @@
       Hasselbacher, RT #41443.
     * Deal with changes in Pod::Parser v1.36 in test in t/05_utils_pod.t.
 
-    Documentation improvements contributed by Mark Grimes in response to RT
-    #41942.
+    [Minor Changes]
+    * Documentation improvements contributed by Mark Grimes in response to RT
+      #41942.
 
-[1.095_001] Released on 2009-01-18
 
-    Changes summarized into 1.096 above.  For exact details, see Changes on
-    BackPAN.
+1.095_001 2009-01-18
 
-[1.094001] Released on 2009-01-01
+    * Changes summarized into 1.096 above.
+      For exact details, see Changes on BackPAN.
 
-    Bug Fixes:
+
+1.094001 2009-01-01
+
+    [Bug Fixes]
     * Tests would fail on systems without Regexp::Parser installed.
 
-[1.094] Released on 2009-01-01
 
-    Incompatible Changes:
+1.094 2009-01-01
+
+    [Incompatible Changes]
     * The way that "## no critic" markers was refactored.  As
       a result, we discovered that the syntax for the markers was pretty
       vague.  If you didn't do it just right, it would disable all policies,
@@ -684,21 +712,21 @@
       Perl::Critic::Violation no longer exist.  Use the corresponding
       get_format() and set_format() functions instead.
 
-    New Policies:
+    [New Policies]
     * Miscellanea::ProhibitUnrestrictedNoCritic
     * Miscellanea::ProhibitUselessNoCritic
     * NamingConventions::Capitalization
     * Subroutines::ProhibitReturnSort
     * Variables::ProhibitReusedNames
 
-    Removed Policies:
+    [Removed Policies]
     * NamingConventions::ProhibitMixedCaseSubs and
       NamingConventions::ProhibitMixedCaseVars have been moved to a separate
       Perl-Critic-Deprecated distribution.  The
       NamingConventions::Capitalization policy does everything they do, plus
       more.
 
-    Policy Changes:
+    [Policy Changes]
     * BuiltinFunctions::ProhibitStringyEval now has an allow_includes option
       that makes it behave (mostly) like Ricardo SIGNES'
       Perl::Critic::Policy::Lax::ProhibitStringyEval::ExceptForRequire.
@@ -719,7 +747,7 @@
       to the strict and warnings pragmata.  This one is for all you Moose fans
       out there.  :]
 
-    Bug Fixes:
+    [Bug Fixes]
     * ControlStructures::ProhibitUnreachableCode would treat package
       statements as unreachable.  Fixed by Kevin Ryde.  RT #41734
     * Fix warning from InputOutput::ProhibitOneArgSelect when select was
@@ -733,36 +761,39 @@
       Perl::Critic::PolicyFactory fell over instead of reporting the
       problematic policy name.
 
-    Miscellanea:
+    [Miscellanea]
     * Perl::Critic::Violation will automatically strip trailing periods
       from your Policy description and explanation strings.  This ensures that
       the punctuation is consistent with the format specified by the user via
       the -verbose formatting options.
 
-    New Developer Features:
+    [New Developer Features]
     * Perl::Critic::Policy::prepare_to_scan_document() is now checked and a
       Policy can disable itself for just a single document, which can speed
       things up.
 
-[1.093_03] Released on 2008-12-11
-[1.093_02] Released on 2008-10-30
-[1.093_01] Released on 2008-09-07
 
-    Changes summarized into 1.094 above.  For exact details, see Changes in
-    1.093_003 on BackPAN.
+1.093_03 2008-12-11
+1.093_02 2008-10-30
+1.093_01 2008-09-07
 
-[1.092] Released on 2008-09-02
+    * Changes summarized into 1.094 above.
+      For exact details, see Changes in 1.093_003 on BackPAN.
 
-    Bug Fixes:
+
+1.092 2008-09-02
+
+    [Bug Fixes]
     * Fixed POD errors that were causing build failures.  Sorry
       about that.
 
-[1.091] Released on 2008-09-01
 
-    New Policies:
+1.091 2008-09-01
+
+    [New Policies]
     * RegularExpressions::RequireDotMatchAnything
 
-    New Features:
+    [New Features]
     * perlcritic now supports a -pager option, so you can more easily
       send the output to your favorite pager.  You can set this option
       on the command-line or in your .perlcriticrc file.  See the
@@ -770,7 +801,7 @@
     * The output from "perlcritic -doc PATTERN" will be automatically
       sent to your pager if you have set the -pager option.
 
-    Policy Changes:
+    [Policy Changes]
     * CodeLayout::ProhibitQuotedWordLists no longer applies if the list
       contains any non-words, by default.  A non-word is anything that does
       not match /[\w-]+/.  You can restore the former behavior by setting the
@@ -791,24 +822,26 @@
       and regexes with the /x modifier.  You can still configure this
       policy to forbid all hard tabs, if you like.  RT #32440
 
-    Bug Fixes:
+    [Bug Fixes]
     * perlcritic should now work under PAR.  RT #38380.
     * URL for our repository in META.yml now works for anonymous
       checkout.  The password is "" (empty).  RT #38628.
     * color for high-severity violations is now magenta because
       it is more redable than yellow on white backgrounds.  RT #38511.
 
-[1.090] Released on 2008-07-22
 
-    Bug Fixes:
+1.090 2008-07-22
+
+    [Bug Fixes]
     * Test was incorrectly failing when Regexp::Parser wasn't installed.
 
-[1.089] Released on 2008-07-21
 
-    Minor Enhancements:
+1.089 2008-07-21
+
+    [Minor Enhancements]
     * -s is now a synonym for --single-policy.
 
-    Policy Changes:
+    [Policy Changes]
     * Subroutines::ProhibitBuiltinHomonyms now also prohibits subroutines
       with the same name as a Perl keyword (e.g. if, foreach, while).
       Inspired by RT #37632.
@@ -825,7 +858,7 @@
       rcs_keywords option to allow for the common case where those require
       dollar signs.
 
-    Bug Fixes:
+    [Bug Fixes]
     * BuiltinFunctions::ProhibitSleepViaSelect would complain if there were
       three undefs as arguments to select(), but one of them was the timeout.
       RT #37416.
@@ -840,15 +873,16 @@
       have a shebang are no longer mistaken as modules.  This prevents
       spurious warnings from Modules::RequireEndWithOne.  RT #20481.
 
-    Internals:
+    [Internals]
     * Tests are now self compliant.
 
-[1.088] Released on 2008-07-04
 
-    New Policies
+1.088 2008-07-04
+
+    [New Policies]
     * ErrorHandling::RequireCheckingReturnValueOfEval
 
-    Policy Changes:
+    [Policy Changes]
     * ValuesAndExpressions::ProhibitLeadingZeros now accepts octal numbers
       for the Unix permissions argument to chmod, dbmopen, mkdir, sysopen, or
       umask, by default.  Use the "strict" option to get the old behavior.
@@ -857,13 +891,14 @@
       Variables::ProhibitUnusedVariables default severity has been raised to
       medium/3.
 
-    Minor Changes:
+    [Minor Changes]
     * The perlcritic "--Version" option is now "--version" in order to act
       like the rest of the world.
 
-[1.087] Released on 2008-06-21
 
-    Policy Changes:
+1.087 2008-06-21
+
+    [Policy Changes]
     * CodeLayout::ProhibitParensWithBuiltins no longer complains about
       sort(foo(@x)).
     * TestingAndDebugging::RequireUseWarnings will not complain about files
@@ -873,7 +908,7 @@
     * InputOutput::ProhibitTwoArgOpen similarly will not complain if there's
       a "use/require 5.005" statement in the file.  RT #34385.
 
-    Bug fixes:
+    [Bug Fixes]
     * Perl::Critic can now critique a file named "0".  However, PPI will give
       a parse error until the next version comes out.  Fixes RT #36127.
     * Moved detection of the lack of any enabled Policies from P::C::Config
@@ -883,54 +918,58 @@
       users@perlcritic.tigris.org and tell us how you're using P::C::Config
       directly so that we can take your needs into account.
 
-[1.086] Released on 2008-06-12
 
-    Policy Changes:
+1.086 2008-06-12
+
+    [Policy Changes]
     * NamingConventions::ProhibitAmbiguousNames now specifies the name that
       it had problems with in its violation descriptions.
 
-    Bug fixes:
+    [Bug Fixes]
     * The color option wasn't being correctly set from a .perlcriticrc.
       RT #36569.
 
-    Minor changes:
+    [Minor Changes]
     * --colour is now a synonym for --color.
 
-[1.085] Released on 2008-06-07
 
-    New Policies:
+1.085 2008-06-07
+
+    [New Policies]
     * Documentation::RequirePackageMatchesPodName
 
-    Policy Changes:
+    [Policy Changes]
     * Variables::ProhibitUnusedVariables detects a few more cases.  It's
       still very limited, though.
 
-    Bug fixes:
+    [Bug Fixes]
     * ControlStructures::ProhibitUnreachableCode didn't notice "until" was an
       conditional expression.
 
-    Minor documentation updates.
+    [Minor Changes]
+    * Documentation updates.
 
-[1.084] Released on 2008-05-24
 
-    New Features:
+1.084 2008-05-24
+
+    [New Features]
     * perlcritic now supports a --list-themes option.
     * You can specify the maximum number of violations you want per Policy
       per document.  Developers can give a default value for this for a
       Policy by overriding default_maximum_violations_per_document().
       See RequireUseStrict and ProhibitMagicNumbers for examples.
 
-    Policy Moved:
+    [Policy Moved]
     * The ValuesAndExpressions::ProhibitMagicNumbers policy has been moved
       from Perl::Critic::More into the primary Perl::Critic distribution.
 
-    New Policies:
+    [New Policies]
     * Variables::ProhibitUnusedVariables (very dumb, limited initial
       implementation.)
     * ControlStructures::ProhibitLabelsWithSpecialBlockNames
       Contributed by Mike O'Regan.  Kickin' ass, Mike.
 
-    Policy Changes:
+    [Policy Changes]
     * ControlStructures::ProhibitUnreachableCode now handles the perl 5.10
       "//" and "err" operators.  RT #36080
     * InputOutput::RequireBriefOpen now ignores opens of STDIN, STDOUT,
@@ -954,40 +993,42 @@
     * Variables::RequireLocalizedPunctuationVars now allows the use of "my".
       RT #33937
 
-    Bug Fixes:
+    [Bug Fixes]
     * No longer falls over if a single file has a parse error.
 
-    New Developer Features:
+    [New Developer Features]
     * If a document specifies a minimum perl version, e.g. "use 5.008003",
       P::C::Document::highest_explicit_perl_version() will tell you what it
       is.
     * The parameter to P::C::Policy::initialize_if_enabled is now a
       P::C::PolicyConfig object instead of a hash reference.
 
-    Minor Changes:
+    [Minor Changes]
     * LOTS of documentation updates.
     * A few more statistics are emitted by perlcritic with the --statistics
       option.
     * perlcritic --profile-proto now includes policy abstracts in its
       output.
 
-    Prerequisites:
+    [Prerequisites]
     * Now depends upon PPI 1.203.
     * New dependency upon version.
 
-[1.083_006] Released on 2008-05-20
-[1.083_005] Released on 2008-05-19
-[1.083_004] Released on 2008-05-18
-[1.083_003] Released on 2008-05-17
-[1.083_002] Released on 2008-05-17
-[1.083_001] Released on 2008-04-13
 
-    Changes summarized into 1.084 above.  For exact details, see Changes in
-    1.083_006 on BackPAN.
+1.083_006 2008-05-20
+1.083_005 2008-05-19
+1.083_004 2008-05-18
+1.083_003 2008-05-17
+1.083_002 2008-05-17
+1.083_001 2008-04-13
 
-[1.082] Released on 2008-03-08
+    * Changes summarized into 1.084 above.
+      For exact details, see Changes in 1.083_006 on BackPAN.
 
-    New Features:
+
+1.082 2008-03-08
+
+    [New Features]
     * A new metadata system for defining policy parameters/options has been
       added.  This makes the life of policy authors easier because
       configuration validation and parsing can be taken care of
@@ -1007,15 +1048,14 @@
 
       There is a discussion of the design considerations for this facility in
       the source repository under doc/PolicyParameter_Notes.pod.
-
     * Added support for "criticism-fatal" option in your perlcriticrc
       file.  This will be used by the criticism pragma to cause execution
       to abort if the file contains any violations.
 
-    New Policy:
+    [New Policy]
     * Module::RequireNoMatchVarsWithUseEnglish
 
-    Policy Changes:
+    [Policy Changes]
     * Added an allow_last_statement_to_be_comma_separated_in_map_and_grep
       option to ValuesAndExpressions::ProhibitCommaSeparatedStatements.
       Partial response to http://rt.cpan.org/Public/Bug/Display.html?id=27654.
@@ -1027,7 +1067,7 @@
     * TestingAndDebugging::RequireUseWarnings now accepts "use Moose" as
       equivalent to "use warnings".
 
-    Bug Fixes:
+    [Bug Fixes]
     * RT #31281 perlcritic doesn't recognize "#!/bin/env perl" shebang
     * Replace usage of Unicode property escapes with POSIX character classes
       order to restore 5.6 compatability.
@@ -1035,24 +1075,26 @@
       about numbered directories in "use lib".
     * Fixed handling of badly behaved spelling programs in PodSpelling.
 
-[1.081_006] Released on 2008-03-02
-[1.081_005] Released on 2007-12-29
-[1.081_004] Released on 2007-12-20
-[1.081_003] Released on 2007-12-16
-[1.081_002] Released on 2007-12-16
-[1.081_001] Released on 2007-12-15
 
-    Changes summarized into 1.082 above.  For exact details, see Changes in
-    1.081_006 on BackPAN.
+1.081_006 2008-03-02
+1.081_005 2007-12-29
+1.081_004 2007-12-20
+1.081_003 2007-12-16
+1.081_002 2007-12-16
+1.081_001 2007-12-15
 
-[1.080] Released on 2007-11-11
+    * Changes summarized into 1.082 above.
+      For exact details, see Changes in 1.081_006 on BackPAN.
 
-    New Features:
+
+1.080 2007-11-11
+
+    [New Features]
     * Allow a "## no critic" statement after a shebang on line 1 of a
       file.  This allows users to block violations that apply to
       whole files and still allow shebangs.
 
-    New Policies: (funded by a Perl Foundation grant)
+    [New Policies - funded by a Perl Foundation grant]
     * InputOutput::ProhibitExplicitStdin
     * RegularExpressions::ProhibitFixedStringMatches
     * RegularExpressions::RequireBracesForMultiline
@@ -1065,75 +1107,73 @@
     * InputOutput::RequireBriefOpen
     * InputOutput::RequireCheckedSyscalls
 
-    Other New Policies
+    [Other New Policies]
     * ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions
 
-    Policy Changes:
+    [Policy Changes]
     * Variables::ProhibitConditionalDeclarations now permits you to local-ize
       variables in conditional declarations.  This makes sense, since
       C<local> is actually a variable modifier, rather than a declaration.
       Thanks to David Golden for reporting this.
 
-    New Developer Features:
+    [New Developer Features]
     * Perl::Critic::Utils::PPIRegexp encapsulates interaction with
       the PPI Regexp token classes.  Those classes have very sparse
       APIs, so this package hides away the ugly fiddling with PPI
       internals.
     * Added a new optional_modules parameter for the .run syntax.
 
-    Bug fixes:
+    [Bug Fixes]
     * PPI::Structure::List can now contain multiple children,
       so P::C::Utils::parse_arg_list() needs to handle it.
-
       This was done in the process of fixing
       http://rt.cpan.org/Ticket/Display.html?id=24924, which was a problem
       with TestingAndDebugging::RequireTestLabels.
-
     * ValuesAndExpressions::ProhibitLongChainsOfMethodCalls wasn't resetting
       chain length when it ran into the end of a sub-expression.
-
       http://rt.cpan.org/Public/Bug/Display.html?id=30040
-
     * ValuesAndExpressions::ProhibitCommaSeparatedStatements was reporting
       false positives when builtins which accept both no and multiple
       arguments were involved.
-
       http://rt.cpan.org/Public/Bug/Display.html?id=27654
 
-    Internals:
+    [Internals]
     * Removed all use of Carp in favor of exceptions.
 
-    Prerequisites:
+    [Prerequisites]
     * Now requires PPI 1.201.  A number of workarounds for PPI bugs have been
       removed.
     * New dependency upon Exception::Class.
 
-    Installation:
+    [Installation]
     * Use Devel::CheckOS to see whether Perl::Critic is being installed on
       a Solaris system and warn about tar(1) chopping file names off if it
       is.
 
-[1.079_003]  Released on 2007-10-22
-[1.079_002]  Released on 2007-10-21
-[1.079_001]  Released on 2007-10-09
 
-    Changes summarized into 1.080 above.  For exact details, see Changes in
-    1.079_003 on BackPAN.
+1.079_003 2007-10-22
+1.079_002 2007-10-21
+1.079_001 2007-10-09
 
-[1.078]  Released on 2007-09-19
+    * Changes summarized into 1.080 above.  For exact details, see Changes in
+      1.079_003 on BackPAN.
 
-    Restore Perl::Critic::TestUtils::should_skip_author_tests() and
-    get_author_test_skip_message().  Some Perl::Critic add-on distributions
-    are using them.
 
-[1.077]  Released on 2007-09-15
+1.078 2007-09-19
 
-    Note: if you don't have any problems installing Perl::Critic 1.076, there
-    is no need to upgrade to this version.  There are no functionality
-    changes.  This release only contains changes related to installation that
-    a few people were experiencing.
+    * Restore Perl::Critic::TestUtils::should_skip_author_tests() and
+      get_author_test_skip_message().  Some Perl::Critic add-on distributions
+      are using them.
 
-    Minor changes:
+
+1.077 2007-09-15
+
+    * Note: if you don't have any problems installing Perl::Critic 1.076, there
+      is no need to upgrade to this version.  There are no functionality
+      changes.  This release only contains changes related to installation that
+      a few people were experiencing.
+
+    [Minor Changes]
     * Removed build-time use of Readonly, again, due to problems some people
       were having when trying to compile the code by hand, rather than using
       CPAN(PLUS)?.
@@ -1144,35 +1184,38 @@
       are not enabled.
 
 
-[1.076]  Released on 2007-09-07
+1.076 2007-09-07
 
-    It appears from reports on the 1.075_001 release that the subroutine
-    sigils were indeed the problem.  Release to the general populace.
+    * It appears from reports on the 1.075_001 release that the subroutine
+      sigils were indeed the problem.  Release to the general populace.
 
 
-[1.075_001]  Released on 2007-09-06
+1.075_001 2007-09-06
 
-    Bug Fixes:
-    Undo the changes in 1.073 and 1.074.  Instead, stop using the subroutine
-    sigil in import and export lists.  It is suspected that the problem lies
-    with Exporter stripping off ampersands.
+    [Bug Fixes]
+    * Undo the changes in 1.073 and 1.074.  Instead, stop using the subroutine
+      sigil in import and export lists.  It is suspected that the problem lies
+      with Exporter stripping off ampersands.
 
-[1.074]  Released on 2007-09-04
 
-    Bug Fixes:
-    Repeat the Makefile.PL change on
-    t/generate_without_optional_dependencies_wrappers.PL.
-    I love CPAN Testers.
+1.074 2007-09-04
 
-[1.073]  Released on 2007-09-04
+    [Bug Fixes]
+    * Repeat the Makefile.PL change on
+      t/generate_without_optional_dependencies_wrappers.PL.
+      I love CPAN Testers.
 
-    Bug Fixes:
-    Work around problems with the combination of Exporter & Readonly in
-    Makefile.PL on some machines.
 
-[1.072]  Released on 2007-09-03
+1.073 2007-09-04
 
-    Bug Fixes:
+    [Bug Fixes]
+    * Work around problems with the combination of Exporter & Readonly in
+      Makefile.PL on some machines.
+
+
+1.072 2007-09-03
+
+    [Bug Fixes]
     * The Makefile generated by Makefile.PL was not syntactically correct
       according to some versions of Solaris.  Thanks to Diab Jerius
       (DJERIUS) for discovery and testing.
@@ -1180,17 +1223,19 @@
       option.
     * Enhanced testing with the absence of optional modules.
 
-[1.071]  Released on 2007-08-24
 
-    The "Brown Paper Bag" Release
+1.071 2007-08-24
 
-    Bug Fixes:
+    * The "Brown Paper Bag" Release
+
+    [Bug Fixes]
     * Tests would not pass in environments that did not have all optional
       dependencies installed.
 
-[1.07]  Released on 2007-08-21
 
-    New Policies: (funded by a Perl Foundation grant)
+1.07 2007-08-21
+
+    [New Policies - funded by a Perl Foundation grant]
     * BuiltinFunctions::ProhibitBooleanGrep
     * BuiltinFunctions::ProhibitComplexMappings
     * Documentation::PodSpelling
@@ -1200,10 +1245,10 @@
     * ValuesAndExpressions::ProhibitImplicitNewlines
     * Variables::RequireLocalizedPunctuationVars
 
-    Other New Policies
+    [Other New Policies]
     * Subroutines::ProhibitNestedSubs
 
-    New Features:
+    [New Features]
     * The "perlcritic --profile-proto" output now includes the "add_themes"
       parameter for each policy.
     * The perlcritic "--strict-profile" option has been replaced with a
@@ -1211,7 +1256,7 @@
       (the default), "fatal", and "quiet", which controls what happens with
       ignorable problems in a .perlcriticrc file.
 
-    New Developer Features:
+    [New Developer Features]
     * Perl::Critic::Policy now has an overridable initialize_if_enabled()
       method which allows a Policy to perform expensive initialization after
       it has been determined whether the user has it enabled or not.  Also,
@@ -1221,75 +1266,71 @@
       Actually, use of this method is now encouraged over using a
       constructor.
 
-    Other Stuff:
+    [Other Stuff]
     * Now requires the Readonly module in order to be more self-compliant.
 
-[1.061]  Released on 2007-07-24
 
-    Bug Fixes:
+1.061 2007-07-24
+
+    [Bug Fixes]
     * Fix P::C::Theme-- Exporter in Perl 5.6 does not export import(), so you
       must subclass it.  *sigh*
     * Fix P::C::Config::_validate_and_save_theme()-- eval of an empty string
       does not reset $@/$EVAL_ERROR in Perl 5.6.
+    * Big thanks to Anirvan Chatterjee for identifying and helping debug these
+      issues.
 
-    Big thanks to Anirvan Chatterjee for identifying and helping debug these
-    issues.
 
-[1.06]  Released on 2007-06-27
+1.06 2007-06-27
 
-    New Features:
+    [New Features]
     * perlcritic now emits errors for all the problems it can find for the
       global options in the command-line parameters and .perlcriticrc file,
       rather than bailing on the first one it encounters.
-
     * perlcritic now has a "--strict-profile" option which will make warnings
       about problems in a profile fatal.
-
     * perlcritic now has a "--statistics-only" option which suppresses the
       display of individual violations and only shows the additional output
       produced by the "--statistics" option.
 
-    Feature requests:
+    [Feature requests]
     * A value for "color" can now be specified in a .perlcriticrc.
       http://rt.cpan.org/Ticket/Display.html?id=24877
 
-    New Policies:
+    [New Policies]
     * ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters
       As suggested in http://rt.cpan.org/Ticket/Display.html?id=23290.
     * ValuesAndExpressions::ProhibitLongChainsOfMethodCalls
     * Modules::ProhibitExcessMainComplexity
       As suggested in http://rt.cpan.org/Ticket/Display.html?id=24699
 
-    Minor changes:
+    [Minor Changes]
     * The perlcritic "--profile-proto" option now emits the short names for
       policies, rather than the full ones.
-
     * The "-profileproto" and "-singlepolicy" options have been renamed to
       "-profile-proto" and "-single-policy" in order to make the growing
       number of command-line options comprehensible.  The change of
       "singlepolicy" also affects your F<.perlcriticrc> file.
 
-[1.053]  Released on 2007-06-02
 
-    *DEVELOPMENT RELEASE*
+1.053 2007-06-02 *DEVELOPMENT RELEASE*
 
-    Bug Fixes:
-    Fixed bug in 15_statustics.t test script, which caused the build
-    to fail on machines that don't have Perl::Tidy installed.
+    [Bug Fixes]
+    * Fixed bug in 15_statistics.t test script, which caused the build
+      to fail on machines that don't have Perl::Tidy installed.
 
-[1.052]  Released on 2007-06-01
 
-    *DEVELOPMENT RELEASE*
+1.052 2007-06-01 *DEVELOPMENT RELEASE*
 
-    New Features:
+    [New Features]
     * perlcritic now emits a summary about the scanned code when enabled by
       the "-statistics" option.
 
-    Policy Enhancements:
+    [Policy Enhancements]
     * InputOutput::ProhibitBacktickOperators can now be configured to only
       check in void contexts.
 
-    Bug Fixes:
+    [Bug Fixes]
     * 27073: False positive in RequireUpperCaseHeredocTerminator
     * 27065: CodeLayout::ProhibitTrailingWhitespace breaks under Perl 5.6.1
     * 26462: ControlStructures::ProhibitCascadingIfElse pod typo
@@ -1297,156 +1338,151 @@
       about multiple values in the list to be iterated over by a foreach loop.
     * Corrected PBP page numbers for some policies (Quinn Weaver).
 
-[1.051]  Released on 2007-04-12
 
-    *DEVELOPMENT RELEASE*
+1.051 2007-04-12 *DEVELOPMENT RELEASE*
 
-    No new policies.
-    No particular bug fixes.
+    * No new policies.
+    * No particular bug fixes.
 
-    Internals:
+    [Internals]
     * Added several new utility functions to support the StricterSubs distro.
       Also, some of the existing functions in Perl-Critic-Utils have
       changed in ways that might break your custom policies.
 
-    Miscellanea:
+    [Miscellanea]
     * Updated Emacs plugin (Courtesy Josh ben Jore).
       See extras/perlcritic.el for details.
     * Added copy of BBEdit plugin (Courtesy of Josh Clark).
       See extras/perl_critic_for_bbedit-1_0.zip for details
 
-[1.05]  Released on 2007-03-19
 
-    Bug Fixes:
+1.05 2007-03-19
+
+    [Bug Fixes]
     * 25557: t/20_policy_prohibittrailingwhitespace.t fails on Perl 5.8.0
 
-[1.04]  Released on 2007-03-18
 
-    Bug Fixes:
+1.04 2007-03-18
+
+    [Bug Fixes]
     * 25008: Subroutines::RequireFinalReturn should allow "throw"
     * 25085: False Positive - Heredoc terminator must be quoted
     * 18423: VERSION check does not notice Readonly::Scalar version
     * 25449: Proposal of $VERSION declaration (DUPLICATE)
 
-    New Policies:
+    [New Policies]
     * CodeLayout::ProhibitTrailingWhitespace
     * ValuesAndExpressions::ProhibitCommaSeparatedStatements
     * Variables::ProhibitPerl4PackageNames
 
-    Policy Enhancements:
+    [Policy Enhancements]
     * Subroutines::RequireFinalReturn can now be configured to recognize
       your custom functions that behave like "die" or "exit".
     * Documentation::RequirePodSections can be configured to match
       Module::Starter:PBP or to really match the PBP book.
 
-[1.03]  Released on 2007-02-13
 
-    Bug Fixes:
+1.03 2007-02-13
+
+    [Bug Fixes]
     * Fixed a few more problems with the %f, %F, and %r format escapes.
     * I forgot to put Conway's perlcriticrc file in the MANIFEST. Sorry.
 
-    Interface Changes:
+    [Interface Changes]
     * Perl::Critic::Utils automatically exports everything.  However,
       this is deprecated.  In the future, you must request your exports.
 
-    Policy Changes:
+    [Policy Changes]
     * Duplicate violations of RequireExcplicitPackage are now squelched,
       in the same way as RequireUseStrict and RequireUseWarnings.
 
-[1.02]  Released on 2007-02-11
 
-    Bug Fixes:
+1.02 2007-02-11
+
+    [Bug Fixes]
     * "undef" incorrectly triggered ProhibitMutatingListFunctions.
     * 24876: %f and %F escapes not working in custom "verbose" format strings.
     * 24875: Documentation bug in TestingAndDebugging::ProhibitNoStrict
 
-    New Policies:
+    [New Policies]
     * InputOutput::RequireCheckedOpen
     * InputOutput::RequireCheckedClose
 
-    Other Cool Stuff:
+    [Other Cool Stuff]
     * Added Conway's own suggested Perl::Critic configuration as
       examples/perlcriticrc-conway.
-
     * See the examples/ directory for some neat demonstrations of using
       the Perl::Critic API. Contributed by Elliot Shank.
 
-    Interface Changes:
+    [Interface Changes]
     * Perl::Critic::Utils no longer exports anything by default.  Policies
       outside the distribution will need to specify what exactly they need
       from this module.  There are a number of tags that can be used in
       addition to individual imports.
 
-[1.01]  Released on 2007-01-24
 
-    PRODUCTION RELEASE:  You may now consider the public Perl::Critic
-    API as "stable."  Future minor releases will focus on bug fixes,
-    new policies, and internal refactoring.
+1.01 2007-01-24
 
-    Bug Fixes:
+    * PRODUCTION RELEASE:  You may now consider the public Perl::Critic
+      API as "stable."  Future minor releases will focus on bug fixes,
+      new policies, and internal refactoring.
+
+    [Bug Fixes]
     * Fixed memory leak.  This was reported by the Parrot team at
       http://rt.perl.org/rt3/Ticket/Display.html?id=41230
 
-[0.23]  Released on 2007-01-19
 
-    Bug Fixes:
+0.23 2007-01-19
+
+    [Bug Fixes]
     * 23994: Test 56 in t/05_utils.t of Perl::Critic v0.22 fails
     * 24005: test 95 in t/13_bundled_policies fails in 0.22
 
-
-    Groovy New Features:
+    [Groovy New Features]
     * Added '%F' to the Violation format specifications.  This will
       give you just the name of file where the violation occurred
       (i.e. without the path).
-
     * Improved validation of .perlcriticrc file.  An invalid
       default setting will now cause a fatal exception. A
       strange-looking policy name will cause a warning.
 
-
-    Interface Changes:
+    [Interface Changes]
     * The syntax for theme expressions has changed.  Instead of using
       mathematical operators qw(+ * -) you must now use the logical
       operators qw(|| && !).  See the Perl::Critic docs for more info.
-
     * The @GLOBALS and @BUILTINS variables are no longer exported by
       Perl::Critic::Utils.  Use the is_perl_global() and is_perl_builtin()
       functions instead.
-
     * Perl::Critic::Policy::policy_parameters() has bee renamed to
       Perl::Critic::Policy::supported_paramters().  This was an
       undocumented feature anyway, so it shouldn't affect anyone.
 
-
-    Other Internal Changes:
+    [Other Internal Changes]
     * Perl::Critic now requires B::Keywords v1.05 or newer.
-
     * A few internal classes have been refactored.  As a result,
       Set::Scalar is no longer a required dependency.
 
 
-[0.22]  Released on 2006-12-15
+0.22 2006-12-15
 
-    New Features:
+    [New Features]
     * Introduced named severity levels: gentle, stern, harsh, cruel, brutal
       You can use these named levels instead of the numeric ones.
       For example: "perlcritic --severity=cruel MyModule.pm"
       Or just:     "perlcritic --cruel MyModule.pm"
-
     * For perlcritic, the "-List" option has been renamed to
       "-profileproto".  The output now includes the names of the
       parameters that each Policy supports, if any.
-
     * Improved validation of Policy parameters in your F<.perlcriticrc>
       Any invalid parameter now causes a fatal exception.
 
-    Major Changes:
+    [Major Changes]
     * Reassigned themes for most policies.  Now there are fewer
       themes and they are organized around programming concepts
       instead of severity levels.  If you have assigned your own
       themes to any Policies, they should still work as expected.
 
-    Policy Changes:
+    [Policy Changes]
     * ErrorHandling::RequireCarping will not complain if it can figure
       out that the die or warn message will always end in a newline
       ("\n").  The idea is that, if you put the newline there, you
@@ -1457,17 +1493,17 @@
       a false value for "allow_messages_ending_with_newlines" in your
       configuration.
 
-    Misc Changes:
+    [Misc Changes]
+    * Added single-letter uppercase alternatives for some perlcritic options.
 
-    Added single-letter uppercase alternatives for some perlcritic options.
 
-[0.21_01] Released on 2006-12-03
+0.21_01 2006-12-03
 
-    New Policies:
+    [New Policies]
     * TestingAndDebugging::ProhibitProlongedStrictureOverride
     * ControlStructures::ProhibitMutatingListFunctions
 
-    New Features:
+    [New Features]
     * Say "perlcritic -List" to get an expanded listing of all Policies.
       The format is suitable for use as your .perlcriticrc file.
     * Say "perlcritic -doc PATTERN" to get the documentation for all
@@ -1479,19 +1515,20 @@
       for packages like File::Find that only interface through
       package variables.
 
-    Bug Fixes:
+    [Bug Fixes]
     * 21713 false positive for parens used with substr and unpack.
     * 22890 allow Rcs keywords in POD.
 
-    Internals:
+    [Internals]
     * Testing system overhauled.  Details on the Policy/subtest
       framework is in t/run.t.
     * Added Perl::Critic::Utils::words_from_string.  This is safer
       than plain old C<split /\s+/>.
 
-[0.21]  Released on 2006-11-05
 
-    New Policies:
+0.21 2006-11-05
+
+    [New Policies]
     * BuiltinFunctions::ProhibitReverseSortBlock
     * BuiltinFunctions::ProhibitVoidGrep
     * BuiltinFunctions::ProhibitVoidMap
@@ -1500,7 +1537,7 @@
     * TestingAndDebugging::RequireTestLabels
     * ValuesAndExpressions::ProhibitMismatchedOperators
 
-    New Features:
+    [New Features]
     * Introduced policy "themes."  Themes are arbitrary names that can
       be used to identify a group of related Policies.  You can select
       your favorite policies by combining themes in a mathematic expression
@@ -1515,7 +1552,7 @@
     * Default values for most of the perlcritic and Perl::Critic options
       can now be defined in your .perlcriticrc file.  See POD for details.
 
-    Bug Fixes:
+    [Bug Fixes]
     * 21236: wrong page number for "printing to filehandles"
     * 21916: File handle ... wrong page reference in PBP [DUPE]
     * 21714: false positive for capture var used in ternary condition
@@ -1527,7 +1564,7 @@
     * Each "for" and "foreach" loop now adds one point to the McCabe
       complexity score.
 
-    Other Stuff:
+    [Other Stuff]
     * The internals of Perl::Critic have been significantly refactored,
       but should still be compatible with existing third-party Policies.
     * Added author-only tests to the release, but disabled by default
@@ -1536,44 +1573,47 @@
     * Additional prerequisite: Set::Scalar
     * Now requires PPI version 1.118
 
-[0.20]  Released on 2006-09-10
 
-    Perl::Critic now requires PPI version 1.117, which fixes
-    several bugs that were introduced in version 1.116.
+0.20 2006-09-10
 
-    Bug Fixes:
+    * Perl::Critic now requires PPI version 1.117, which fixes
+      several bugs that were introduced in version 1.116.
+
+    [Bug Fixes]
     * 21079: grep clears @SITE_POLICIES
     * 21352: Test failures with PPI 1.117
     * 11365: sub DESTROY detected as a builtin homonym
 
-[0.19]  Released on 2006-08-20
 
-    New Policies:
+0.19 2006-08-20
+
+    [New Policies]
     * BuiltinFunctions::ProhibitStringySplit
     * ControlStructures::ProhibitDeepNests
     * RegularExpressions::ProhibitCaptureWithoutTest
     * Variables::RequireLexicalLoopIterator
 
-    New Features:
+    [New Features]
     * "perlcritic -quiet" suppresses the "source OK" message.
     * Variables::ProhibitPunctuationVars is now configurable.
 
-    Bug Fixes:
+    [Bug Fixes]
     * 20965: "Hard tabs used at" shouldn't check __DATA__
     * 21070: ProhibitNoisyQuotes hates overload
     * Punctuation variables are now exempt from ProhibitLocalVars
 
-    Other Stuff:
+    [Other Stuff]
     * Test coverage is now over 95%
 
-[0.18_01]  Released on 2006-08-06
 
-    New Policies:
+0.18_01 2006-08-06
+
+    [New Policies]
     * Variables::RequireNegativeIndices
     * InputOutput::ProhibitInteractiveTest
     * ErrorHandling::RequireCarping
 
-    Bug Fixes:
+    [Bug Fixes]
     * RequireTidyCode tests fail if user has custom .perltidyrc file
     * 20612: RequirePerlTidy was ignoring HEREDOCs
     * 20659: __END__ statement considered "unreachable"
@@ -1581,7 +1621,7 @@
     * Support for 'goto' in ProhibitAmpersandSigils and
       Subroutines::RequireFinalReturn
 
-    Performance Enhancements:
+    [Performance Enhancements]
     * Introduced Perl::Critic::Document class.  This is a facade for
       PPI::Document which internally caches search results.  This
       reduces the running time by about 35%.  The facade should be
@@ -1590,13 +1630,14 @@
       until it is really needed.  Speedup has not been measured.
     * Calls to helper-subs have been reordered for maximum efficiency.
 
-    Other Cool Stuff:
+    [Other Cool Stuff]
     * Includes updated version of perlcritic mode for emacs.  See
       "extras/perlcritic.el" for details.
 
-[0.18]  Released on 2006-07-16
 
-    Bug Fixes:
+0.18 2006-07-16
+
+    [Bug Fixes]
     * 14855: Home discovery is dangerously naive.
     * 20060: Incorrect page numbers in ProhibitLeadingZeros
       and RequireNumberSeparator policies.
@@ -1607,68 +1648,71 @@
     * ProhibitExcessComplexity doesn't count 'while' and 'until' stmnts
     * ProhibitLeadingZeros was falsely hits '.0456'
 
-    Enhancements:
+    [Enhancements]
     * If File::HomeDir is available, we use it to locate the
       .perlcriticrc file.  This should help make Perl::Critic
       more portable to Win32 platforms.  If File::HomeDir is
       not installed, we resort to looking at the usual
       environment variables.
 
-    Other Stuff:
+    [Other Stuff]
     * Added "perlcritic.el", which is a super-cool emacs minor-mode
       that runs perl-critic on the current buffer and returns the
       results in a sexy hot-linked "compiler" window.  You can run
       it on demand, or have it run automatically every time you
       save the buffer.  You can find this in the extras/ directory.
       Thanks to Josh ben Jore for contributing this.
-
     * Moved "Perl::Critic::TestUtils" into the installed build.  This
       module is only used for unit-testing Perl::Critic, but we
       are putting it in the installation so folks who want to
       extend Perl::Critic can make use of it.
 
-[0.17]  Released on 2006-06-13
 
-    Bug Fixes:
+0.17 2006-06-13
+
+    [Bug Fixes]
     * 19836: Perl-Critic0.16 fails tests during install.  This was
       caused by a bug in version 3.01 of Module::Pluggable.  See
       http://rt.cpan.org/Ticket/Display.html?id=19857 for details.
     * Fixed bug in no-critic pragma parser.
 
-    New Policies:
+    [New Policies]
     * ValuesAndExpressions::ProhibitEscapedCharacters
     * BuiltinFunctions::RequireSimpleSortBlock
 
-    Enhancements:
+    [Enhancements]
     * Perl::Critic can export critique() as a static function.  This
       may appeal to folks who dislike the object-oriented interface.
 
-[0.16]  Released on 2006-05-14
 
-    Enhancements:
+0.16 2006-05-14
+
+    [Enhancements]
     * Perl::Critic->critique() now accepts a PPI::Document as the
       argument.  This feature creates an additional dependency on
       Scalar::Util, but that shouldn't be a problem because it is
       included with List::Util, which we already use.
 
-    Miscellanea:
+    [Miscellanea]
     * Increased PPI dependency from v1.110 to v1.112
 
-[0.15_03] Released on 2006-05-07
 
-    Bug Fixes:
+0.15_03 2006-05-07
+
+    [Bug Fixes]
     * The "## no critic" feature is now implemented without eval-ing
       the code.  This keeps Perl::Critic pure and safe :)
     * 19082: Page number for AUTOLOAD is incorrect
 
-    New Policies:
+    [New Policies]
     * ControlStructures::ProhibitUnreachableCode (by Peter Guzis)
     * Modules::ProhibitAutomaticExportation
     * ValuesAndExpressions::ProhibitVersionStrings
 
-[0.15_02] Released on 2006-04-26
 
-    Bug Fixes:
+0.15_02 2006-04-26
+
+    [Bug Fixes]
     * Reimplemented the '##no critic' pragmas to have effect on the
       line where the violation is reported, not on the line where
       the candidate element lives.  This is because some policies
@@ -1684,9 +1728,10 @@
     * Fixed -noprofile option on 'perlcritic'.  This also had stopped
       working at some point.
 
-[0.15_01] Released on 2006-04-16
 
-    Enhancements:
+0.15_01 2006-04-16
+
+    [Enhancements]
     * Added diagnostic messages if the .perlcriticrc contains entries
       for Policy modules that don't seem to exist.
     * Now you can specify which policies to disable with the
@@ -1696,121 +1741,115 @@
       as *.swp, *.bak and *~.  It also ignores version control system
       directories, and the blib directory in module build directories.
 
-    Bug Fixes:
+    [Bug Fixes]
     * 18386: Bad example in POD for Documentation::RequirePodSections
     * 18670: Test failure if Perl::Tidy is not installed
     * 18698: Policy idea ProhibitUniversalFunctions (see New Policies)
     * RequireInterpolationOfMetachars falsely hit strings like 'foo=s@'
       which are commonly used with Getopt::Long.
 
-    New Policies:
+    [New Policies]
     * BuiltinFunctions::ProhibitUniversalCan (by Chris Dolan)
     * BuiltinFunctions::ProhibitUniversalIsa (by Chris Dolan)
 
-    Miscellanea:
+    [Miscellanea]
     * All spurrious options for `perlcritic` are now fatal.
     * Changed several of the -verbose formats to be more readable.
     * Explicit -severity option now overrides -[12345] shortcuts instead
       of being the other way around.
 
 
+0.15 2006-03-26
 
-[0.15] Released on 2006-03-26
-
-    Bug Fixes:
+    [Bug Fixes]
     * 17964: Insists my code is not tidy (may not be fixed for all cases)
 
-[0.14_02] Released on 2006-03-19
 
-    Bug Fixes:
+0.14_02 2006-03-19
+
+    [Bug Fixes]
     * 15653: False positive in OneArgSelect (fixed for real this time)
 
-    New Policies:
+    [New Policies]
     * ClassHierarchies::ProhibitAutoloading
     * Documentation::RequirePodSections
     * InputOutput::RequireBracedFileHandleWithPrint
     * ValuesAndExpressions::ProhibitMixedBooleanOperators
     * Variables::RequireInitializationForLocalVars
 
-[0.14_01] Released on 2006-03-05
 
-    Bug Fixes:
+0.14_01 2006-03-05
+
+    [Bug Fixes]
     * 14731: False positive: Builtin function called with parens
     * 17554: False positive in CodeLayout::RequireTrailingCommas
 
-    New Policies:
+    [New Policies]
     * ClassHierarchies::ProhibitExplicitISA
     * InputOutput::ProhibitReadlineInForLoop
     * Miscellanea::ProhibitFormats
     * Miscellanea::ProhibitTies
     * Variables::ProhibitConditionalDeclarations
 
-[0.14] Released on 2006-01-29
 
-    More documentation edits.
+0.14 2006-01-29
 
-    New Policies:
+    * More documentation edits.
+
+    [New Policies]
     * Documentation::RequirePodAtEnd
     * Subroutines::ProtectPrivateSubs
     * Variables::ProhibitMatchVars
     * Variables::ProtectPrivateVars
 
-    Bug Fixes:
+    [Bug Fixes]
     * 15295: "## no critic" pragmas too aggresive on compound statements.
     * t/01_config.t failed in the presence of third-party policies
-
-[0.13_05] Not released
-
-    More documentation edits.
-
-    Implemented workaround for failing pod_coverage tests.
-
-    Bug Fixes:
+    * Implemented workaround for failing pod_coverage tests.
     * 16906:  tr/// created false-postives with RegularExpression polices.
 
-[0.13_04] Released on 2005-12-31
 
-    Moved DEVELOPER.pod file into the Perl/Critic dir.
+0.13_04 2005-12-31
 
-    More documentation edits.
+    * Moved DEVELOPER.pod file into the Perl/Critic dir.
+    * More documentation edits.
 
-[0.13_03] Released on 20051230
 
-    perlcritic now prints 'source OK' if it doesn't find any
-    violations.  This gives folks a warm fuzzy feeling.
+0.13_03 2005-12-30
 
-    Tweaked some test cases that were failing on my Solaris
-    environment at work.
+    * perlcritic now prints 'source OK' if it doesn't find any
+      violations.  This gives folks a warm fuzzy feeling.
+    * Tweaked some test cases that were failing on my Solaris
+      environment at work.
 
-[0.13_02] Released on 2005-12-29
 
-    Fixed Config to recognize fully-qualified module names in the
-    .perlcriticrc file.
+0.13_02 2005-12-29
 
-    Various documentation edits.
+    * Fixed Config to recognize fully-qualified module names in the
+      .perlcriticrc file.
+    * Various documentation edits.
 
-[0.13_01] Released on 2005-12-28
 
-    Replaced 'priority' concept with 'severity'.  Now each Policy module
-    has a predefined severity level ranging from 1 to 5.  By default,
-    perlcritic only reports the most severe violations.  You can adjust
-    the severity threshold at the command line, and you can change
-    the severity for any Policy using the config file.
+0.13_01 2005-12-28
 
-    Chris implemented the applies_to() mechanism, which allows each Policy
-    class to declare the types of PPI elements that it wants to examine.
-    When traversing the document, Perl::Critic invokes the Policy only
-    for elements that are of the correct type.  This improves performance
-    by about 33%.
+    * Replaced 'priority' concept with 'severity'.  Now each Policy module
+      has a predefined severity level ranging from 1 to 5.  By default,
+      perlcritic only reports the most severe violations.  You can adjust
+      the severity threshold at the command line, and you can change
+      the severity for any Policy using the config file.
+    * Chris implemented the applies_to() mechanism, which allows each Policy
+      class to declare the types of PPI elements that it wants to examine.
+      When traversing the document, Perl::Critic invokes the Policy only
+      for elements that are of the correct type.  This improves performance
+      by about 33%.
+    * Perl::Critic now uses a Plugin architecture to automatically
+      discover Policy modules.  So if you have custom Policies, all you
+      have to do is install them in the Perl::Critic::Policy namespace --
+      no need to add anything to your .perlcriticrc file.  If you write
+      policies in a different namespace, you can configure that too.  See
+      the Perl::Critic::Config docs for details.
 
-    Perl::Critic now uses a Plugin architecture to automatically
-    discover Policy modules.  So if you have custom Policies, all you
-    have to do is install them in the Perl::Critic::Policy namespace --
-    no need to add anything to your .perlcriticrc file.  If you write
-    policies in a different namespace, you can configure that too.  See
-    the Perl::Critic::Config docs for details.
-
-    New Policies:
+    [New Policies]
     * Modules::RequireEndWithOne
     * NamingConventions::ProhibitAmbiguousNames
     * References::ProhibitDoubleSigils
@@ -1820,85 +1859,58 @@
     * TestingAndDebugging::ProhibitNoStrict
     * TestingAndDebugging::ProhibitNoWarnings
 
-    Bug Fixes:
+    [Bug Fixes]
     * 15101: Plugin architecture improves support for 3rd-party code
     * 16319: Fixed incorrect PBP page number in ProhibitBarwordFilehandle
     * 16321: Lists of empty quotes are now allowed by ProhibitQuotedWordLists
     * 16288: Empty lists caused a fatal error RequireTrailingCommas
     * 15653: Fixed false positive in OneArgSelect.
 
-[0.13] Released on 2005-10-31
 
-    Official release of 0.12_03.  No code major changes.
+0.13 2005-10-31
 
-[0.12_03] Not released
+    * Renamed -Policy option to -include.  Added -exclude to give the
+      opposite effect.
+    * Refactored constructor of Perl::Critic.  Now, most of the work
+      is delegated to Perl::Critic::Config.  I'm not sure I like how
+      this turned out, but we'll see how it goes.
+    * Renamed some Policy modules to be a bit more comprehensible.  Note
+      that you may need to change your .perlcriticrc file accordingly.
+      I also suggest removing your current Perl::Critic installation
+      before installing this one.
+    * Improved error message when Perl::Critic dies because PPI can't
+      parsee the input code.
+    * Changed output of -help to be more terse.
+    * Added -Policy option to perlcritic.  The idea is to provide a
+      compact interface for selecting Policy modules at the command-line.
+      This feature is experimental and subject to change.
+    * Added a warning message if -verbose value looks strange.  In most
+      applications, the -verbose option does not require a value, so people
+      might be puzzled when they write 'perlcritic -verbose my_file.pm' and
+      nothing seems to happen.
+    * Command-line options to perlcritic are now case-sensitive.  This
+      makes it easier to abbreviate options that start with the same letters
+      (e.g. 'Version' and 'verbose')
+    * Fixed the new Policy modules that were misnamed and misplaced in the
+      previous distribution.
+    * Rewrote some of the ControlStructures and BuiltinFunction
+      policies to be simpler (and probably a little faster).
+    * Edited POD.  Fixed some typos.  Added PREREQUISITES section
+      to Perl::Critic documentation.
+    * Fixed the -verbose FORMAT option so that you can put metachars
+      in the FORMAT specification.  If using perlcritic, be careful to
+      protect them from getting munged by the shell first.
+    * Replaced ProhibitRequireStatements with RequireBarewordIncludes
+      module. Courtesy of Chris Dolan <cdolan@cpan.org>
+    * Added configuration to ProhibitInterpolationOfLiterals so that
+      certain flavors of quotes can be exempt.  This is for folks who
+      have configured their editor to use special syntax highlighting
+      for certain kinds of strings (SQL, for example).
+    * perlcritic now accepts multiple file arguments, so now you can
+      critique your entire distribution in one shot.  As a result, the
+      output-formats have changed slightly.
 
-    Renamed -Policy option to -include.  Added -exclude to give the
-    opposite effect.
-
-    Refactored constructor of Perl::Critic.  Now, most of the work
-    is delegated to Perl::Critic::Config.  I'm not sure I like how
-    this turned out, but we'll see how it goes.
-
-    Renamed some Policy modules to be a bit more comprehensible.  Note
-    that you may need to change your .perlcriticrc file accordingly.
-    I also suggest removing your current Perl::Critic installation
-    before installing this one.
-
-    Name Changes:
-    * ProhibitUnpackagedCode => RequireExplicitPackage
-    * RequireQuotedWords     => ProhibitQuotedWordLists
-
-    Improved error message when Perl::Critic dies because PPI can't
-    parsee the input code.
-
-    Changed output of -help to be more terse.
-
-    Edited POD.
-
-[0.12_02] Not released
-
-    Added -Policy option to perlcritic.  The idea is to provide a
-    compact interface for selecting Policy modules at the command-line.
-    This feature is experimental and subject to change.
-
-    Added a warning message if -verbose value looks strange.  In most
-    applications, the -verbose option does not require a value, so people
-    might be puzzled when they write 'perlcritic -verbose my_file.pm' and
-    nothing seems to happen.
-
-    Command-line options to perlcritic are now case-sensitive.  This
-    makes it easier to abbreviate options that start with the same letters
-    (e.g. 'Version' and 'verbose')
-
-    Fixed the new Policy modules that were misnamed and misplaced in the
-    previous distribution.
-
-[0.12_01] Not released
-
-    Rewrote some of the ControlStructures and BuiltinFunction
-    policies to be simpler (and probably a little faster).
-
-    Edited POD.  Fixed some typos.  Added PREREQUISITES section
-    to Perl::Critic documentation.
-
-    Fixed the -verbose FORMAT option so that you can put metachars
-    in the FORMAT specification.  If using perlcritic, be careful to
-    protect them from getting munged by the shell first.
-
-    Replaced ProhibitRequireStatements with RequireBarewordIncludes
-    module. Courtesy of Chris Dolan <cdolan@cpan.org>
-
-    Added configuration to ProhibitInterpolationOfLiterals so that
-    certain flavors of quotes can be exempt.  This is for folks who
-    have configured their editor to use special syntax highlighting
-    for certain kinds of strings (SQL, for example).
-
-    perlcritic now accepts multiple file arguments, so now you can
-    critique your entire distribution in one shot.  As a result, the
-    output-formats have changed slightly.
-
-    New Policy modules:
+    [New Policies]
     * BuiltinFunctions::ProhibitLvalueSubstr
     * BuiltinFunctions::ProhibitSleepViaSelect
     * ClassHierarchies::ProhibitOneArgBless
@@ -1912,62 +1924,61 @@
     * RegularExpressions::RequireExtendedFormatting
     * RegularExpressions::RequireLineBoundaryMatching
 
+    [Name Changes]
+    * ProhibitUnpackagedCode => RequireExplicitPackage
+    * RequireQuotedWords     => ProhibitQuotedWordLists
 
-    Bug fixes:
+    [Bug Fixes]
     14923: 'require' is now permitted. See RequireBarewordIncludes.
     15022: Fixed false-positives when keywords are used as hash keys.
     15023: Fixed spurious Violations by removing magic shebang.
     15031: Fixed spelling mistakes (and probably added some new ones).
     15233: Postfix 'if' is now allowed with 'die', 'croak', etc.
 
-[0.12] Released 2005-10-10
 
-    Redesigned the 'verbose' feature.  Now the output format
-    can be user-defined using a sprintf-like specification.
-    perlciritc also has a predefined output format that is
-    compatible with grep mode in editors like vim and emacs.
+0.12 2005-10-10
 
-    'return' is now exempt from ProhibitParensWithBuiltins.  I may
-    extend this exemption to all unary functions.
+    * The internal dynamics and API of Perl::Critic have changed
+      considerably.  The result is a 300% increase in performance.
+      See the POD in Perl::Critic::Policy for details.
+    * Redesigned the 'verbose' feature.  Now the output format
+      can be user-defined using a sprintf-like specification.
+      perlciritc also has a predefined output format that is
+      compatible with grep mode in editors like vim and emacs.
+    * 'return' is now exempt from ProhibitParensWithBuiltins.  I may
+      extend this exemption to all unary functions.
+    * Edited POD. Added a super brief description of each policy
+      in the main Perl::Critic documentation.  Added details about
+      editor integration.
 
-    Edited POD. Added a super brief description of each policy
-    in the main Perl::Critic documentation.  Added details about
-    editor integration.
-
-    Additional Prerequisites:
-    * String::Format
-
-[0.11] Not released
-
-    The internal dynamics and API of Perl::Critic have changed
-    considerably.  The result is a 300% increase in performance.
-    See the POD in Perl::Critic::Policy for details.
-
-    New Features:
+    [New Features]
     * Added -verbose option to put more stuff in the output.  In the
       extreme, you can get the POD from Policy attached to each
       and every violation.
 
-    Additional Prerequisites:
+    [Additional Prerequisites]
+    * String::Format
     * IO::String
     * Pod::PlainText
 
-[0.10] Released 2005-10-05
 
-    Fixed stupid bug in newest Policy modules.  They were returning
-    PPI objects instead of Perl::Critic::Violation objects.  Doh!
+0.10 2005-10-05
 
-    Fixed test scripts to prevent failures if the user already has a
-    .perlcriticrc file.
+    * Fixed stupid bug in newest Policy modules.  They were returning
+      PPI objects instead of Perl::Critic::Violation objects.  Doh!
+    * Fixed test scripts to prevent failures if the user already has a
+      .perlcriticrc file.
+    * 'ProhibitHardTabs' now allows leading tabs by default.
+    * Put the Changes file in reverse-chronological order, so the most
+      recent stuff is easy to find at the top of the file
 
-    'ProhibitHardTabs' now allows leading tabs by default.
 
-    Put the Changes file in reverse-chronological order, so the most
-    recent stuff is easy to find at the top of the file
+0.09 2005-10-04
 
-[0.09] Released 2005-10-04
+    * Changed the syntax for the magic comments.  Adam had the
+      idea of using a pragma-like notation.  I liked it.
 
-    Fixed several bugs:
+    [Bug Fixes]
     * 14810: Now you are allowed to create your own 'import' function,
              since this is frequently done with fancy modules.
     * 14817: Parens, brackets, and braces are now excluded from
@@ -1980,126 +1991,100 @@
     * 14855: Partially fixed home directory discovery.  Still not
              completely portable, but at least doesn't create warnings.
 
-    New features:
+    [New features]
     * 14734: Limit for number separators is now configurable
 
-    New Policy modules:
+    [New Policy modules]
     * CodeLayout::ProhibitHardTabs
     * ControlStructures::ProhibitUnlessBlocks
     * ControlStructures::ProhibitUntilBlocks
     * ControlStructures::ProhibitCStyleForLoops
 
-    Changed the syntax for the magic comments.  Adam had the
-    idea of using a pragma-like notation.  I liked it.
 
-[0.08_2] Released 2005-09-27
+0.08_2 2005-09-27
 
-    Fixed problems with Perl::Critic::Config that caused File::Spec
-    to emit 'uninitialized value' warnings during the build.
+    * Fixed problems with Perl::Critic::Config that caused File::Spec
+      to emit 'uninitialized value' warnings during the build.
+    * Added 1 Policy module contributed by Graham TerMarsch
+    * Switched from File::Spec::Functions to plain File::Spec because
+      I think its usage is more common.
+    * Removed 'FindBin' from the test files so I can be sure that the
+      right libraries are getting loaded.  This means I'll have to
+      use the -l option with C<prove>.
+    * Fixed "ProhibitParensWithBuiltins" to allow parens to be used with
+      object method calls that have the same name as a builtin functions.
+    * Introduced magical comments that allow developers to configure
+      Perl::Critic on-the-fly from within their code.
+    * Added META.yml files and POD tests to the build.  I did this
+      mostly just to boost the Kwalitee score on CPANTS.
+    * Switched from "Config::Std" to "Config::Tiny" because it doesn't
+      require those fancy Damian modules that don't seem to work on
+      some older versions of Perl.
+    * Edited more POD.
 
-    Added 1 Policy module contributed by Graham TerMarsch
 
-    Switched from File::Spec::Functions to plain File::Spec because
-    I think its usage is more common.
+0.07 2005-09-21
 
-    Removed 'FindBin' from the test files so I can be sure that the
-    right libraries are getting loaded.  This means I'll have to
-    use the -l option with C<prove>.
+    * Fixed bugs in the ProhibitCascadingIfElse policy.
+    * Added ProhibitExplicitReturnUndef policy
+    * Made ProhibitUnpackagedCode configurable so you can exempt scripts,
+      which typically don't have an explicit 'package' statement.
+    * ProhibitPackageVars policy now exempts vars in ALL_CAPS.  This
+      is to permit common package variables like @EXPORT and $VERSION.
+    * Renamed "ProhibitStringyGrep and "ProhibitStringyMap" because
+      the so-called string form doesn't really exist.  Now called
+      "RequireBlockGrep" and "RequireBlockMap"
+    * Corrected documentation on defining Policy names within the
+      configuration file.  This still isn't very clear and needs
+      to be rewritten.
+    * Perl::Critic now requires PPI version 1.003, which has a few bug
+      fixes of its own.
+    * Rewrite some code just to make Perl::Critic more self-compliant.
+    * Added test cases to verify the configuration functionality.  These
+      are not completely thorough and need more work.
 
-    Edited more POD.
 
-[0.08_01] Not released
+0.06 2005-09-17
 
-    Fixed "ProhibitParensWithBuiltins" to allow parens to be used with
-    object method calls that have the same name as a builtin functions.
+    * Now called 'Perl::Critic'.
+    * Added 4 new policy modules.
+    * Fixed bugs in build process.
+    * Added support for Module::Build.
 
-    Introduced magical comments that allow developers to configure
-    Perl::Critic on-the-fly from within their code.
 
-    Added META.yml files and POD tests to the build.  I did this
-    mostly just to boost the Kwalitee score on CPANTS.
+0.05 2005-09-17
 
-    Switched from "Config::Std" to "Config::Tiny" because it doesn't
-    require those fancy Damian modules that don't seem to work on
-    some older versions of Perl.
+    * End of 'Perl::Review' releases.  I have changed the name to
+      'Perl::Critic' to avoid possible confusion with "The Perl Review"
+      magazine.
 
-[0.07] Released on 2005-09-21
 
-    Fixed bugs in the ProhibitCascadingIfElse policy.
+0.04 2005-09-14
 
-    Added ProhibitExplicitReturnUndef policy
+    * Version 0.03 was a bust because I uploaded the wrong tarball to PAUSE.
 
-    Made ProhibitUnpackagedCode configurable so you can exempt scripts,
-    which typically don't have an explicit 'package' statement.
 
-    ProhibitPackageVars policy now exempts vars in ALL_CAPS.  This
-    is to permit common package variables like @EXPORT and $VERSION.
+0.03 2005-09-13
 
-    Renamed "ProhibitStringyGrep and "ProhibitStringyMap" because
-    the so-called string form doesn't really exist.  Now called
-    "RequireBlockGrep" and "RequireBlockMap"
+    * Fixed some POD links.
+    * Removed test cases for missing policy module.
 
-    Corrected documentation on defining Policy names within the
-    configuration file.  This still isn't very clear and needs
-    to be rewritten.
 
-    Perl::Critic now requires PPI version 1.003, which has a few bug
-    fixes of its own.
+0.02 2005-09-13
 
-    Rewrite some code just to make Perl::Critic more self-compliant.
+    * Major overhaul based on feedback from Perl community.
+    * Factored coding standards into separate modules (known as
+      Policies).  The idea here is to allow other developers to easily
+      contribute additional coding standards.
+    * Reworked Perl::Review into a simple engine for loading and running
+      Policy modules.
+    * Gave perlreview a command-line interface and configuration file
+      for selecting which Policy modules to use.
 
-    Added test cases to verify the configuration functionality.  These
-    are not completely thorough and need more work.
 
-[0.06] Released on 2005-09-17
+0.01 2005-08-16
 
-    Now called 'Perl::Critic'.
+    * Initial version.
 
-    Added 4 new policy modules.
-
-    Fixed bugs in build process.
-
-    Added support for Module::Build.
-
-[0.05] Released on 2005-09-17
-
-    End of 'Perl::Review' releases.  I have changed the name to
-    'Perl::Critic' to avoid possible confusion with "The Perl Review"
-    magazine.
-
-[0.04] Released on 2005-09-14
-
-    Version 0.03 was a bust because I uploaded the wrong tarball to PAUSE.
-
-[0.03] Released on 2005-09-13.
-
-    Fixed some POD links.
-
-    Removed test cases for missing policy module.
-
-[0.02] Released on 2005-09-13.
-
-    Major overhaul based on feedback from Perl community.
-
-    Factored coding standards into separate modules (known as
-    Policies).  The idea here is to allow other developers to easily
-    contribute additional coding standards.
-
-    Reworked Perl::Review into a simple engine for loading and running
-    Policy modules.
-
-    Gave perlreview a command-line interface and configuration file
-    for selecting which Policy modules to use.
-
-[0.01] Released on 2005-08-16.
-
-    Initial version.
-
-##############################################################################
-#      $URL: http://perlcritic.tigris.org/svn/perlcritic/trunk/distributions/Perl-Critic/Changes $
-#     $Date: 2013-09-25 21:18:04 -0700 (Wed, 25 Sep 2013) $
-#   $Author: thaljef $
-# $Revision: 4169 $
-##############################################################################
 
 # ex: set ts=8 sts=4 sw=4 tw=78 ft= expandtab shiftround :


### PR DESCRIPTION
Hi Jeff,

The main changes were:
- removed [ and ] from around release numbers
- consistent use of [section labels]
- consistent spacing and indenting of bullets
- merged 'not released' changes into the next CPAN release
- moved flags like _DEVELOPER RELEASE_ onto the release header line

That's an impressive Changes file, which reflects the impressive work you've done on Perl::Critic!

Neil
