### PR TITLE
is_assignment_operator: exclude != 

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -1169,12 +1169,12 @@ sub words_from_string {
 
 #-----------------------------------------------------------------------------
 
+Readonly::Hash my %ASSIGNMENT_OPERATORS => hashify( qw( = **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //= ) );
+
 sub is_assignment_operator {
     my $elem = shift;
 
-    return if $elem !~ m/= \Z/xms;
-    return if $elem =~ m/\A [=<>] = \Z/xms;  # Exclude == >= <=
-    return 1;
+    return $ASSIGNMENT_OPERATORS{ $elem };
 }
 
 #-----------------------------------------------------------------------------

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 141;
+use Test::More tests => 153;
 
 #-----------------------------------------------------------------------------
 
@@ -110,15 +110,11 @@ sub test_find_keywords {
 #-----------------------------------------------------------------------------
 
 sub test_is_assignment_operator {
+    is( is_assignment_operator($_), 1, "$_ is an assignment operator" )
+        for qw( = **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //= );
 
-    for ( qw(||= &&= //= += *= -= >>= <<=) ) {
-        is( is_assignment_operator($_), 1, "$_ is an assignment operator" )
-    }
-
-
-    for ( qw(== =~ >= <= + - * / %) ) {
-        is( !!is_assignment_operator($_), q{}, "$_ is not an assignment operator" )
-    }
+    is( !!is_assignment_operator($_), q{}, "$_ is not an assignment operator" )
+        for qw( == != =~ >= <= + - * / % x bogus= );
 
     return;
 }


### PR DESCRIPTION
Prevent != from being counted as an assignment operator.
Prevent foo= from being counted as an assignment operator.
Test that = is an assignment operator.
Fix is_assignment_operator POD markup.
