### PR TITLE
Don't return violation if a match was seen

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireFilenameMatchesPackage.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireFilenameMatchesPackage.pm
@@ -71,7 +71,8 @@ sub violates {
         last if ($path_part =~ m/\W/xms);
 
         # Mismatched name
-        return $self->violation( $DESC, $EXPL, $pkg_node );
+        return $self->violation( $DESC, $EXPL, $pkg_node )
+          unless $matched_any;
     }
 
     return if $matched_any;


### PR DESCRIPTION
This corrects the problem described in #568 -- if a match of at least one element between `@pkg_parts` and `@path_parts` has been seen, don't return a policy violation. 
