### PR TITLE
Switch File::Slurp for Path::Tiny

### DIFF
--- a/lib/Perl/Critic/DEVELOPER.pod
+++ b/lib/Perl/Critic/DEVELOPER.pod
@@ -760,7 +760,7 @@ parsed value for later use by the C<violates()> method.
 An example parser (without enough error handling) for the above
 example declaration:
 
-    use File::Slurp qw< slurp >;
+    use Path::Tiny;
 
     use Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue
         qw{ throw_policy_value };
@@ -779,7 +779,7 @@ example declaration:
                     message_suffix => 'is not readable.';
             }
 
-            @thingies = slurp $config_string;
+            @thingies = path($config_string)->slurp;
         }
 
         $self->{_thingies} = \@thingies;

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
@@ -13,7 +13,7 @@ our $VERSION = '1.121_01';
 
 #-----------------------------------------------------------------------------
 
-Readonly::Scalar my $DESC => q{Use "local $/ = undef" or File::Slurp instead of joined readline}; ## no critic qw(InterpolationOfMetachars)
+Readonly::Scalar my $DESC => q{Use "local $/ = undef" or Path::Tiny instead of joined readline}; ## no critic qw(InterpolationOfMetachars)
 Readonly::Scalar my $EXPL => [213];
 
 #-----------------------------------------------------------------------------
@@ -51,7 +51,7 @@ __END__
 
 =head1 NAME
 
-Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline - Use C<local $/ = undef> or L<File::Slurp|File::Slurp> instead of joined readline.
+Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline - Use C<local $/ = undef> or L<Path::Tiny|Path::Tiny> instead of joined readline.
 
 =head1 AFFILIATION
 
@@ -70,7 +70,7 @@ like so:
 
   do { local $/ = undef; <$fh> }
 
-or use L<File::Slurp|File::Slurp>, which is even faster.
+or use L<Path::Tiny|Path::Tiny>, which is even faster.
 
 B<Note> that if the C<ProhibitPunctuationVars> policy is also in effect,
 it will complain about the use of C<$/> in the line above.  In that

--- a/lib/Perl/Critic/Policy/Variables/RequireLocalizedPunctuationVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/RequireLocalizedPunctuationVars.pm
@@ -135,7 +135,7 @@ magic variable in a non-trivial program, do it in a local scope.
 
 For example, to slurp a filehandle into a scalar, it's common to set
 the record separator to undef instead of a newline.  If you choose to
-do this (instead of using L<File::Slurp|File::Slurp>!) then be sure to
+do this (instead of using L<Path::Tiny|Path::Tiny>!) then be sure to
 localize the global and change it for as short a time as possible.
 
     # BAD:


### PR DESCRIPTION
Hi, thanks for your work on this module.

This short pull request is to move from File::Slurp to Path::Tiny.
File::Slurp has a currently critical bug:

https://rt.cpan.org/Public/Bug/Display.html?id=83126

See also:

https://rt.perl.org/Ticket/Display.html?id=121870
