### PR TITLE
Importing import() from Exporter requires Exporter 5.57+

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ NEXT
     [Bug Fixes]
     * The RequireChecked* family of policies has been fixed to accommodate
       version numbers when use-ing the autodie pragma. GH #612. Thanks citrin.
+    * Importing the import() from Exporter requires Exporter 5.57+
 
 1.123 2014-11-11
 

--- a/lib/Perl/Critic.pm
+++ b/lib/Perl/Critic.pm
@@ -7,7 +7,7 @@ use warnings;
 use English qw(-no_match_vars);
 use Readonly;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 use File::Spec;
 use List::MoreUtils qw< firstidx >;

--- a/lib/Perl/Critic/Command.pm
+++ b/lib/Perl/Critic/Command.pm
@@ -25,7 +25,7 @@ our $VERSION = '1.123';
 
 #-----------------------------------------------------------------------------
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 Readonly::Array our @EXPORT_OK => qw< run >;
 

--- a/lib/Perl/Critic/Exception.pm
+++ b/lib/Perl/Critic/Exception.pm
@@ -15,7 +15,7 @@ use Exception::Class (
     },
 );
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 #-----------------------------------------------------------------------------
 

--- a/lib/Perl/Critic/PolicyParameter.pm
+++ b/lib/Perl/Critic/PolicyParameter.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 Readonly::Array our @EXPORT_OK => qw{ $NO_DESCRIPTION_AVAILABLE };
 

--- a/lib/Perl/Critic/TestUtils.pm
+++ b/lib/Perl/Critic/TestUtils.pm
@@ -7,7 +7,7 @@ use warnings;
 use English qw(-no_match_vars);
 use Readonly;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 use File::Path ();
 use File::Spec ();

--- a/lib/Perl/Critic/Theme.pm
+++ b/lib/Perl/Critic/Theme.pm
@@ -6,7 +6,7 @@ use warnings;
 use English qw(-no_match_vars);
 use Readonly;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 use List::MoreUtils qw(any);
 

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -18,7 +18,7 @@ use PPI::Token::Quote::Single;
 use Perl::Critic::Exception::Fatal::Generic qw{ throw_generic };
 use Perl::Critic::Utils::PPI qw< is_ppi_expression_or_generic_statement >;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Perl/Critic/Utils/Constants.pm
+++ b/lib/Perl/Critic/Utils/Constants.pm
@@ -7,7 +7,7 @@ use Readonly;
 
 use Perl::Critic::Utils qw{ $EMPTY hashify };
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Perl/Critic/Utils/DataConversion.pm
+++ b/lib/Perl/Critic/Utils/DataConversion.pm
@@ -7,7 +7,7 @@ use Readonly;
 
 use Perl::Critic::Utils qw{ :characters :booleans };
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Perl/Critic/Utils/McCabe.pm
+++ b/lib/Perl/Critic/Utils/McCabe.pm
@@ -8,7 +8,7 @@ use Readonly;
 
 use Perl::Critic::Utils qw{ :data_conversion :classification };
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 #-----------------------------------------------------------------------------
 

--- a/lib/Perl/Critic/Utils/POD.pm
+++ b/lib/Perl/Critic/Utils/POD.pm
@@ -15,7 +15,7 @@ use Perl::Critic::Exception::Fatal::Generic qw< throw_generic >;
 use Perl::Critic::Exception::IO qw< throw_io >;
 use Perl::Critic::Utils qw< :characters >;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Perl/Critic/Utils/PPI.pm
+++ b/lib/Perl/Critic/Utils/PPI.pm
@@ -8,7 +8,7 @@ use Readonly;
 
 use Scalar::Util qw< blessed readonly >;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Perl/Critic/Utils/Perl.pm
+++ b/lib/Perl/Critic/Utils/Perl.pm
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 our $VERSION = '1.123';
 

--- a/lib/Test/Perl/Critic/Policy.pm
+++ b/lib/Test/Perl/Critic/Policy.pm
@@ -24,7 +24,7 @@ our $VERSION = '1.123';
 
 #-----------------------------------------------------------------------------
 
-use Exporter 'import';
+use Exporter 5.57 'import';
 
 Readonly::Array our @EXPORT_OK      => qw< all_policies_ok >;
 Readonly::Hash  our %EXPORT_TAGS    => (all => \@EXPORT_OK);


### PR DESCRIPTION
Hi Jeff,

You were doing the following in a few modules:

    use Exporter 'import';

Support for this was added in Exporter 5.57, and since Perl::Critic supports 5.6.x, it's safest to specify the min version of Exporter.

I noticed some tests fail, but I'm assuming they were already failing in the version I grabbed from github :-)

Cheers,
Neil