### PR TITLE
skip_when_using option for Subroutines::ProhibitUnusedPrivateSubroutines

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl module Perl::Critic
 
 NEXT
 
+    [Policy Changes]
+    * Subroutines::ProhibitUnusedPrivateSubroutines can now ignore files that
+      use particular modules with 'skip_when_using' option allows of, for
+      example, skipping the policy for roles.  Thanks to Mark Fowler.
+
     [Bug Fixes]
     * The RequireChecked* family of policies has been fixed to accommodate
       version numbers when use-ing the autodie pragma. GH #612. Thanks citrin.

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
@@ -378,6 +378,19 @@ which looks at the other side of the problem.
 Does not forbid C<< sub Foo::_foo{} >> because it does not know (and can not
 assume) what is in the C<Foo> package.
 
+Does not respect the scope caused by multiple packages in the same file.  For
+example a file:
+
+    package Foo;
+    sub _is_private { print "A private sub!"; }
+
+    package Bar;
+    _is_private();
+
+Will not trigger a violation even though C<Foo::_is_private> is not called.
+Similarly, C<skip_when_using> currently works on a I<file> level, not on a
+I<package scope> level.
+
 
 =head1 SEE ALSO
 

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
@@ -46,7 +46,7 @@ sub supported_parameters {
         {
             name            => 'skip_when_using',
             description     =>
-                q<Classes that, if used within a package, will cause the policy to be disabled for this package>,
+                q<Modules that, if used within a package, will cause the policy to be disabled for this package>,
             default_string  => $EMPTY,
             behavior        => 'string list',
         },
@@ -359,7 +359,7 @@ above allows C<< sub _bar {} >> and C<< sub _baz {} >>, even if they are not
 referred to in the module that defines them.
 
 You can configure this policy not to check private subroutines declared in a
-file that uses one or more particular named classes.  This allows you to, for
+file that uses one or more particular named modules.  This allows you to, for
 example, exclude unused private subroutine checking in classes that are roles.
 
     [Subroutines::ProhibitUnusedPrivateSubroutines]

--- a/t/Subroutines/ProhibitUnusedPrivateSubroutines.run
+++ b/t/Subroutines/ProhibitUnusedPrivateSubroutines.run
@@ -234,6 +234,19 @@ sub _second {
 }
 
 #-----------------------------------------------------------------------------
+
+## name skip_when_using
+## failures 0
+## parms { skip_when_using => 'Moose::Role' }
+## cut
+
+use Moose::Role;
+
+sub _private {
+    print "A private sub\n";
+}
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
Hello,

So, sometimes we build objects out of several roles, with roles providing private methods.  However, these roles trigger Subroutines::ProhibitUnusedPrivateSubroutines as the private subroutines they provide are not consumed until the roles are consumed together in the final class.  We would like to disable this policy automatically whenever a class uses 'Moose::Role".

This patch adds a skip_when_using option for Subroutines::ProhibitUnusedPrivateSubroutines that allows you to specify a list of modules that, if used in a file, disables Subroutines::ProhibitUnusedPrivateSubroutines for that file.

