### PR TITLE
allow brackets in ## no critic annotations

### DIFF
--- a/lib/Perl/Critic.pm
+++ b/lib/Perl/Critic.pm
@@ -758,10 +758,11 @@ family of Policies in one shot like this:
     # Now exempt from NamingConventions::Capitalization
     sub camelHumpSub {}
 
-The argument list must be enclosed in parentheses and must contain one or more
-comma-separated barewords (e.g. don't use quotes).  The C<"## no critic">
-annotations can be nested, and Policies named by an inner annotation will be
-disabled along with those already disabled an outer annotation.
+The argument list must be enclosed in parentheses or brackets and must contain
+one or more comma-separated barewords (e.g. don't use quotes).
+The C<"## no critic"> annotations can be nested, and Policies named by an inner
+annotation will be disabled along with those already disabled an outer
+annotation.
 
 Some Policies like C<Subroutines::ProhibitExcessComplexity> apply to an entire
 block of code.  In those cases, the C<"## no critic"> annotation must appear

--- a/lib/Perl/Critic/Annotation.pm
+++ b/lib/Perl/Critic/Annotation.pm
@@ -223,7 +223,7 @@ sub _parse_annotation {
     # verified as a no-critic annotation.  So if this regex does not match,
     # then it implies that all Policies are to be disabled.
     #
-    my $no_critic = qr{\#\# \s* no \s+ critic \s* (?:qw)? [("'] ([\s\w:,]+) }xms;
+    my $no_critic = qr{\#\# \s* no \s+ critic \s* (?:qw)? [(["'] ([\s\w:,]+) }xms;
     #                  -------------------------- ------- ----- -----------
     #                                 |              |      |        |
     #   "## no critic" with optional spaces          |      |        |


### PR DESCRIPTION
Allows to use brackets in ## no critic annotations.
```
no critic qw[SomePoilicy]
```
This will be handy for people, who accustomed to using brackets as qw delimiter.