### PR TITLE
Fixed perltidy complaining about backups with dest and source

### DIFF
--- a/lib/Perl/Critic/Policy/CodeLayout/RequireTidyCode.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/RequireTidyCode.pm
@@ -83,7 +83,8 @@ sub violates {
     # another program.  Also, we need to override the
     # stdout and stderr redirects that the user may have
     # configured in their .perltidyrc file.
-    local @ARGV = qw(-nst -nse);
+    # Also override -b because we are using dest and source.
+    local @ARGV = qw(-nst -nse -nb);
 
     # Trap Perl::Tidy errors, just in case it dies
     my $eval_worked = eval {


### PR DESCRIPTION
This fixes a complication with perltidy where the user has -b specified in their perltidyrc file. Because the code uses a destination and source explicitly, if -b is turned on perltidy fails even though the code is tidy.