### PR TITLE
Adds even more strict/warnings importer modules.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Perl::Critic
 
+    [Miscellanea]
+    * Add more strict/warnings importer modules.
+
 1.125 2015-03-02
 
     [Bug Fixes]

--- a/lib/Perl/Critic/Utils/Constants.pm
+++ b/lib/Perl/Critic/Utils/Constants.pm
@@ -102,6 +102,10 @@ Readonly::Array our @STRICT_EQUIVALENT_MODULES => qw(
     Mouse::Util
     Mouse::Util::TypeConstraints
 
+    Moos
+
+    Mousse
+
     Any::Moose
 
     Modern::Perl
@@ -112,6 +116,8 @@ Readonly::Array our @STRICT_EQUIVALENT_MODULES => qw(
     Mojolicious::Lite
     Mojo::Base
 
+    sane
+    shit
     strictures
 );
 


### PR DESCRIPTION
Nothing really critical here, but found these via http://grep.cpan.me/?q=strict-%3Eimport  There are likely more that could be added.

I notice that `common::sense` is not included here.  I assume that's because it only does `use strict qw(vars subs);`  If that's the case, it might be worth noting as a comment.