### PR TITLE
added code to allow for exempting files based on regex to Modules::RequireExplicitPackage

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
@@ -26,6 +26,11 @@ sub supported_parameters {
             behavior       => 'boolean',
         },
         {
+            name           => 'exempt_files',
+            description    => q{Ignore files matching this pattern.},
+            behavior       => 'string',
+        },
+        {
             name           => 'allow_import_of',
             description    => q{Allow the specified modules to be imported outside a package},
             behavior       => 'string list',
@@ -43,6 +48,11 @@ sub default_maximum_violations_per_document { return 1; }
 
 sub prepare_to_scan_document {
     my ( $self, $document ) = @_;
+
+    return 0 if exists $self->{_exempt_files}
+        && defined $self->{_exempt_files}
+        && $self->{_exempt_files} ne ''
+        && $document->filename =~ /^$self->{_exempt_files}$/;
 
     return ! $self->{_exempt_scripts} || $document->is_module();
 }


### PR DESCRIPTION
This is a redo of #646. I got much less broken tests after branching from dev.  With prove and 'prove -l' I got the following:
## Test Summary Report

t/01_config.t                               (Wstat: 256 Tests: 237 Failed: 1)
  Failed test:  175
  Non-zero exit status: 1
t/12_theme_listing.t                        (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
t/13_bundled_policies.t                     (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
t/16_roundtrip_defaults.t                   (Wstat: 256 Tests: 686 Failed: 1)
  Failed test:  329
  Non-zero exit status: 1

With a lot of uninitialized warnings, though I think some of them were not mine.  I'll see what I can find.

t/01_config.t:265 'include pattern matching' is failing. I'm not sure what this is testing.

I don't think t/12_theme_listing.t and t/13_bundled_policies.t are mine. Unless I'm missing something, which is entirely possible.

t/16_roundtrip_defaults.t:256 is failing with 'Modules::RequireExplicitPackage _exempt_files match' so that's pretty obviously mine. I'm not sure what I'm doing wrong here.

With 'prove -b' I only got the t/16_roundtrip_defaults.t error (with 4 less total tests) but the problem was the same.
