### PR TITLE
Favour $elem->content eq 'foo' over $elem eq 'foo'

### DIFF
--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitBooleanGrep.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitBooleanGrep.pm
@@ -30,7 +30,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'grep';
+    return if $elem->content() ne 'grep';
     return if not is_function_call($elem);
     return if not _is_in_boolean_context($elem);
 

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitComplexMappings.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitComplexMappings.pm
@@ -39,7 +39,7 @@ sub applies_to        { return 'PPI::Token::Word'                   }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'map';
+    return if $elem->content() ne 'map';
     return if ! is_function_call($elem);
 
     my $sib = $elem->snext_sibling();

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitLvalueSubstr.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitLvalueSubstr.pm
@@ -41,7 +41,7 @@ sub prepare_to_scan_document {
 sub violates {
     my ($self, $elem, undef) = @_;
 
-    return if $elem ne 'substr';
+    return if $elem->content() ne 'substr';
     return if ! is_function_call($elem);
 
     my $sib = $elem;

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitReverseSortBlock.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitReverseSortBlock.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'    }
 sub violates {
     my ($self, $elem, $doc) = @_;
 
-    return if $elem ne 'sort';
+    return if $elem->content() ne 'sort';
     return if ! is_function_call($elem);
 
     my $sib = $elem->snext_sibling();

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitSleepViaSelect.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitSleepViaSelect.pm
@@ -28,7 +28,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ($self, $elem, undef) = @_;
 
-    return if ($elem ne 'select');
+    return if $elem->content() ne 'select';
     return if ! is_function_call($elem);
 
     my @arguments = parse_arg_list($elem);

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringyEval.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringyEval.pm
@@ -39,7 +39,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'eval';
+    return if $elem->content() ne 'eval';
     return if not is_function_call($elem);
 
     my $argument = first_arg($elem);

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringySplit.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringySplit.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'    }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'split';
+    return if $elem->content() ne 'split';
     return if ! is_function_call($elem);
 
     my @args = parse_arg_list($elem);

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitVoidGrep.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitVoidGrep.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'grep';
+    return if $elem->content() ne 'grep';
     return if not is_function_call($elem);
     return if not is_in_void_context($elem);
 

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitVoidMap.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitVoidMap.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'map';
+    return if $elem->content() ne 'map';
     return if not is_function_call($elem);
     return if not is_in_void_context($elem);
 

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/RequireBlockGrep.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/RequireBlockGrep.pm
@@ -31,7 +31,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'grep';
+    return if $elem->content() ne 'grep';
     return if ! is_function_call($elem);
 
     my $arg = first_arg($elem);

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/RequireSimpleSortBlock.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/RequireSimpleSortBlock.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'                   }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'sort';
+    return if $elem->content() ne 'sort';
     return if ! is_function_call($elem);
 
     my $sib = $elem->snext_sibling();

--- a/lib/Perl/Critic/Policy/ClassHierarchies/ProhibitOneArgBless.pm
+++ b/lib/Perl/Critic/Policy/ClassHierarchies/ProhibitOneArgBless.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ($self, $elem, undef) = @_;
 
-    return if $elem ne 'bless';
+    return if $elem->content() ne 'bless';
     return if ! is_function_call($elem);
 
     if( scalar parse_arg_list($elem) == 1 ) {

--- a/lib/Perl/Critic/Policy/ControlStructures/ProhibitCascadingIfElse.pm
+++ b/lib/Perl/Critic/Policy/ControlStructures/ProhibitCascadingIfElse.pm
@@ -50,7 +50,7 @@ sub violates {
 sub _count_elsifs {
     my $elem = shift;
     return
-      grep { $_->isa('PPI::Token::Word') && $_ eq 'elsif' } $elem->schildren();
+      grep { $_->isa('PPI::Token::Word') && $_->content() eq 'elsif' } $elem->schildren();
 }
 
 1;

--- a/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
+++ b/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
@@ -40,7 +40,7 @@ sub _is_topic {
     my $elem = shift;
     return defined $elem
         && $elem->isa('PPI::Token::Magic')
-            && $elem eq q{$_}; ##no critic (InterpolationOfMetachars)
+            && $elem->content() eq q{$_}; ##no critic (InterpolationOfMetachars)
 }
 
 
@@ -199,7 +199,7 @@ sub _is_topic_mutating_func {
     my $elem = shift;
     return if not $elem->isa('PPI::Token::Word');
     my @mutator_funcs = qw(chop chomp undef);
-    return if not any { $elem eq $_ } @mutator_funcs;
+    return if not any { $elem->content() eq $_ } @mutator_funcs;
     return if not is_function_call( $elem );
 
     # If these functions have no argument,
@@ -207,7 +207,7 @@ sub _is_topic_mutating_func {
     my $first_arg = first_arg( $elem );
     if (not defined $first_arg) {
         # undef does not default to $_, unlike the others
-        return if $elem eq 'undef';
+        return if $elem->content() eq 'undef';
         return 1;
     }
     return _is_topic( $first_arg );
@@ -219,7 +219,7 @@ Readonly::Scalar my $MUTATING_SUBSTR_ARG_COUNT => 4;
 
 sub _is_topic_mutating_substr {
     my $elem = shift;
-    return if $elem ne 'substr';
+    return if $elem->content() ne 'substr';
     return if not is_function_call( $elem );
 
     # check and see if the first arg is $_

--- a/lib/Perl/Critic/Policy/ControlStructures/ProhibitNegativeExpressionsInUnlessAndUntilConditions.pm
+++ b/lib/Perl/Critic/Policy/ControlStructures/ProhibitNegativeExpressionsInUnlessAndUntilConditions.pm
@@ -28,7 +28,7 @@ sub applies_to           { return 'PPI::Token::Word'         }
 sub violates {
     my ( $self, $token, undef ) = @_;
 
-    return if $token ne 'until' && $token ne 'unless';
+    return if $token->content() ne 'until' && $token->content() ne 'unless';
 
     return if is_hash_key($token);
     return if is_subroutine_name($token);
@@ -85,7 +85,7 @@ sub _get_condition_elements {
     my $element = $token;
     while (
             $element = $element->snext_sibling()
-        and $element ne $SCOLON
+        and $element->content() ne $SCOLON
     ) {
         push @condition_elements, $element;
     }

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordFileHandles.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordFileHandles.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ($self, $elem, undef) = @_;
 
-    return if $elem ne 'open';
+    return if $elem->content() ne 'open';
     return if ! is_function_call($elem);
 
     my $first_arg = ( parse_arg_list($elem) )[0];

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitInteractiveTest.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitInteractiveTest.pm
@@ -26,7 +26,7 @@ sub applies_to           { return 'PPI::Token::Operator' }
 
 sub violates {
     my ($self, $elem, $doc) = @_;
-    return if $elem ne '-t';
+    return if $elem->content() ne '-t';
     return $self->violation( $DESC, $EXPL, $elem );
 }
 

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
@@ -28,7 +28,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'join';
+    return if $elem->content() ne 'join';
     return if ! is_function_call($elem);
     my @args = parse_arg_list($elem);
     shift @args; # ignore separator string

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitOneArgSelect.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitOneArgSelect.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'  }
 sub violates {
     my ($self, $elem, undef) = @_;
 
-    return if $elem ne 'select';
+    return if $elem->content() ne 'select';
     return if ! is_function_call($elem);
 
     my @arguments = parse_arg_list($elem);

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitTwoArgOpen.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitTwoArgOpen.pm
@@ -34,7 +34,7 @@ sub applies_to           { return 'PPI::Token::Word'         }
 sub violates {
     my ($self, $elem, $document) = @_;
 
-    return if $elem ne 'open';
+    return if $elem->content() ne 'open';
     return if ! is_function_call($elem);
 
     my $version = $document->highest_explicit_perl_version();

--- a/lib/Perl/Critic/Policy/InputOutput/RequireCheckedClose.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/RequireCheckedClose.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'close';
+    return if $elem->content() ne 'close';
     return if ! is_unchecked_call( $elem );
 
     return $self->violation( $DESC, $EXPL, $elem );

--- a/lib/Perl/Critic/Policy/InputOutput/RequireCheckedOpen.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/RequireCheckedOpen.pm
@@ -27,7 +27,7 @@ sub applies_to           { return 'PPI::Token::Word'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne 'open';
+    return if $elem->content() ne 'open';
     return if ! is_unchecked_call( $elem );
 
     return $self->violation( $DESC, $EXPL, $elem );

--- a/lib/Perl/Critic/Policy/Miscellanea/ProhibitFormats.pm
+++ b/lib/Perl/Critic/Policy/Miscellanea/ProhibitFormats.pm
@@ -26,7 +26,7 @@ sub applies_to           { return 'PPI::Token::Word'         }
 
 sub violates {
     my ( $self, $elem, undef ) = @_;
-    return if $elem ne 'format';
+    return if $elem->content() ne 'format';
     return if ! is_function_call( $elem );
     return $self->violation( $DESC, $EXPL, $elem );
 }

--- a/lib/Perl/Critic/Policy/Miscellanea/ProhibitTies.pm
+++ b/lib/Perl/Critic/Policy/Miscellanea/ProhibitTies.pm
@@ -26,7 +26,7 @@ sub applies_to           { return 'PPI::Token::Word'       }
 
 sub violates {
     my ( $self, $elem, undef ) = @_;
-    return if $elem ne 'tie';
+    return if $elem->content() ne 'tie';
     return if ! is_function_call( $elem );
     return $self->violation( $DESC, $EXPL, $elem );
 }

--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
@@ -130,8 +130,8 @@ sub _enough_assignments {
     while (1) {
         return if !$psib;
         if ($psib->isa('PPI::Token::Operator')) {
-            last SIBLING if q{=} eq $psib;
-            return if q{!~} eq $psib;
+            last SIBLING if q{=} eq $psib->content;
+            return if q{!~} eq $psib->content;
         }
         $psib = $psib->sprevious_sibling;
     }
@@ -235,7 +235,7 @@ sub _is_in_slurpy_array_context {
 
     # look backward for explicit regex operator
     my $psib = $elem->sprevious_sibling;
-    if ($psib && $psib eq q{=~}) {
+    if ($psib && $psib->content eq q{=~}) {
         # Track back through value
         $psib = _skip_lhs($psib);
     }
@@ -271,7 +271,7 @@ sub _is_in_slurpy_array_context {
     }
     if ($psib->isa('PPI::Token::Operator')) {
         # most operators kill slurpiness (except assignment, which is handled elsewhere)
-        return $TRUE if q{,} eq $psib;
+        return $TRUE if q{,} eq $psib->content;
         return;
     }
     return $TRUE;

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitExplicitReturnUndef.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitExplicitReturnUndef.pm
@@ -26,13 +26,13 @@ sub applies_to           { return 'PPI::Token::Word' }
 
 sub violates {
     my ( $self, $elem, undef ) = @_;
-    return if ($elem ne 'return');
+    return if $elem->content() ne 'return';
     return if is_hash_key($elem);
 
     my $sib = $elem->snext_sibling();
     return if !$sib;
     return if !$sib->isa('PPI::Token::Word');
-    return if $sib ne 'undef';
+    return if $sib->content() ne 'undef';
 
     # Must be 'return undef'
     return $self->violation( $DESC, $EXPL, $elem );

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
@@ -78,7 +78,7 @@ sub _count_args {
     my $statement = shift @statements;
     my @elements = $statement->schildren();
     my $operand = pop @elements;
-    while ($operand && $operand->isa('PPI::Token::Structure') && q{;} eq $operand) {
+    while ($operand && $operand->isa('PPI::Token::Structure') && q{;} eq $operand->content()) {
        $operand = pop @elements;
     }
     return 0 if !$operand;
@@ -87,11 +87,11 @@ sub _count_args {
     my $operator = pop @elements;
     return 0 if !$operator;
     return 0 if !$operator->isa('PPI::Token::Operator');
-    return 0 if q{=} ne $operator;
+    return 0 if q{=} ne $operator->content();
 
-    if ($operand->isa('PPI::Token::Magic') && $AT_ARG eq $operand) {
+    if ($operand->isa('PPI::Token::Magic') && $AT_ARG eq $operand->content()) {
        return _count_list_elements(@elements);
-    } elsif ($operand->isa('PPI::Token::Word') && 'shift' eq $operand) {
+    } elsif ($operand->isa('PPI::Token::Word') && 'shift' eq $operand->content()) {
        return 1 + _count_args(@statements);
     }
 

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitReturnSort.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitReturnSort.pm
@@ -26,13 +26,13 @@ sub applies_to           { return 'PPI::Token::Word' }
 
 sub violates {
     my ( $self, $elem, undef ) = @_;
-    return if ($elem ne 'return');
+    return if $elem->content() ne 'return';
     return if is_hash_key($elem);
 
     my $sib = $elem->snext_sibling();
     return if !$sib;
     return if !$sib->isa('PPI::Token::Word');
-    return if $sib ne 'sort';
+    return if $sib->content() ne 'sort';
 
     # Must be 'return sort'
     return $self->violation( $DESC, $EXPL, $elem );

--- a/lib/Perl/Critic/Policy/Subroutines/ProtectPrivateSubs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProtectPrivateSubs.pm
@@ -161,7 +161,8 @@ sub _is_other_pkg_private_method {
     # sometimes the previous sib is a keyword, as in:
     # shift->_private_method();  This is typically used as
     # shorthand for "my $self=shift; $self->_private_method()"
-    return if $package eq 'shift' or $package eq '__PACKAGE__';
+    return if $package->content() eq 'shift'
+        or $package->content() eq '__PACKAGE__';
 
     # Maybe the user wanted to exempt this explicitly.
     return if $self->{_allow}{"${package}::$content"};

--- a/lib/Perl/Critic/Policy/Subroutines/RequireFinalReturn.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/RequireFinalReturn.pm
@@ -114,7 +114,7 @@ sub _is_compound_return {
     my $begin = $final->schild(0);
     return if !$begin; #fail
     if (!($begin->isa('PPI::Token::Word') &&
-          ($begin eq 'if' || $begin eq 'unless'))) {
+          ($begin->content() eq 'if' || $begin->content() eq 'unless'))) {
         return; #fail
     }
 
@@ -197,7 +197,8 @@ sub _is_return_or_goto_stmnt {
     my ( $self, $stmnt ) = @_;
     return if not $stmnt->isa('PPI::Statement::Break');
     my $first_token = $stmnt->schild(0) || return;
-    return $first_token eq 'return' || $first_token eq 'goto';
+    return $first_token->content() eq 'return'
+        || $first_token->content() eq 'goto';
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
@@ -46,7 +46,7 @@ sub violates {
         next DECLARATION if 'my' ne $declaration->type();
 
         my @children = $declaration->schildren();
-        next DECLARATION if any { $_ eq q<=> } @children;
+        next DECLARATION if any { $_->content() eq q<=> } @children;
 
         VARIABLE:
         foreach my $variable ( $declaration->variables() ) {

--- a/lib/Perl/Critic/Policy/Variables/RequireLocalizedPunctuationVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/RequireLocalizedPunctuationVars.pm
@@ -45,7 +45,7 @@ sub applies_to           { return 'PPI::Token::Operator'     }
 sub violates {
     my ( $self, $elem, undef ) = @_;
 
-    return if $elem ne q{=};
+    return if $elem->content() ne q{=};
 
     my $destination = $elem->sprevious_sibling;
     return if !$destination;  # huh? assignment in void context??
@@ -69,7 +69,8 @@ sub _is_non_local_magic_dest {
         if
                 $modifier
             &&  $modifier->isa('PPI::Token::Word')
-            &&  ($modifier eq 'local' || $modifier eq 'my');
+            &&  ($modifier->content() eq 'local'
+                || $modifier->content() eq 'my');
 
     # Implementation note: Can't rely on PPI::Token::Magic,
     # unfortunately, because we need English too


### PR DESCRIPTION
PPI::Element overloads eq. It first works out which side is an
instance of a PPI::Element, calls "content" on that instance, and
then compares against the other side.

This layer of indirection can be avoided by just calling "content"
ourselves.

A small(ish) run on serverity 1 of around 20k lines went from 18s
to 16s.

I only changed the policies I saw when putting a caller(1) call
into PPI::Element's eq overload sub, it's entirely possible that
there are others.