### PR TITLE
Add fc & say to ProhibitUselessTopic

### DIFF
--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitUselessTopic.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitUselessTopic.pm
@@ -29,6 +29,7 @@ my @topical_funcs = qw(
     chomp chop chr chroot cos
     defined
     eval exp
+    fc
     glob
     hex
     int
@@ -38,7 +39,7 @@ my @topical_funcs = qw(
     pos print
     quotemeta
     readlink readpipe ref require reverse rmdir
-    sin split sqrt stat study
+    say sin split sqrt stat study
     uc ucfirst unlink unpack
 );
 my %topical_funcs = map { ($_ => 1) } @topical_funcs;


### PR DESCRIPTION
As per title, this tiny change adds both fc() and say() to the BuiltinFunctions::ProhibitUselessTopic policy as they both operate on $_ if EXPR is omitted.