### PR TITLE
allowing two-arg open of STDIN/STDOUT/STDERR is not needed

### DIFF
--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitTwoArgOpen.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitTwoArgOpen.pm
@@ -15,7 +15,6 @@ our $VERSION = '1.125';
 
 #-----------------------------------------------------------------------------
 
-Readonly::Scalar my $STDIO_HANDLES_RX => qr/\b STD (?: IN | OUT | ERR \b)/xms;
 Readonly::Scalar my $FORK_HANDLES_RX => qr/\A (?: -[|] | [|]- ) \z/xms;
 Readonly::Scalar my $DESC => q{Two-argument "open" used};
 Readonly::Scalar my $EXPL => [ 207 ];
@@ -43,9 +42,6 @@ sub violates {
     my @args = parse_arg_list($elem);
 
     if ( scalar @args == 2 ) {
-        # When opening STDIN, STDOUT, or STDERR, the
-        # two-arg form is the only option you have.
-        return if $args[1]->[0] =~ $STDIO_HANDLES_RX;
         return if $args[1]->[0]->isa( 'PPI::Token::Quote' )
                && $args[1]->[0]->string() =~ $FORK_HANDLES_RX;
         return $self->violation( $DESC, $EXPL, $elem );
@@ -106,9 +102,8 @@ This Policy is not configurable except for the standard options.
 
 =head1 NOTES
 
-There are two cases in which you are forced to use the two-argument form of
-open. When re-opening STDIN, STDOUT, or STDERR, and when doing a safe pipe
-open, as described in L<perlipc|perlipc>.
+There is one case in which you are forced to use the two-argument form of
+open: when doing a safe pipe open, as described in L<perlipc|perlipc>.
 
 =head1 SEE ALSO
 

--- a/t/InputOutput/ProhibitTwoArgOpen.run
+++ b/t/InputOutput/ProhibitTwoArgOpen.run
@@ -48,8 +48,8 @@ $foo{open}; # not a function call
 
 #-----------------------------------------------------------------------------
 
-## name no three-arg equivalent passes
-## failures 0
+## name io handle failures
+## failures 11
 ## cut
 
 open( STDOUT, '>&STDOUT' );
@@ -60,6 +60,40 @@ open( \*STDOUT, '>&STDERR' );
 open( *STDOUT, '>&STDERR' );
 open( STDOUT, '>&STDERR' );
 
+# Other file modes.
+open( \*STDOUT, '>>&STDERR' );
+open( \*STDOUT, '<&STDERR' );
+open( \*STDOUT, '+>&STDERR' );
+open( \*STDOUT, '+>>&STDERR' );
+open( \*STDOUT, '+<&STDERR' );
+
+#-----------------------------------------------------------------------------
+
+## name io handle passes
+## failures 0
+## cut
+
+open( STDOUT, '>&', \*STDOUT );
+open( STDIN, '>&', \*STDIN );
+open( STDERR, '>&', \*STDERR );
+
+open( \*STDOUT, '>&', \*STDERR );
+open( *STDOUT, '>&', \*STDERR );
+open( STDOUT, '>&', \*STDERR );
+
+# Other file modes.
+open( \*STDOUT, '>>&', \*STDERR );
+open( \*STDOUT, '<&', \*STDERR );
+open( \*STDOUT, '+>&', \*STDERR );
+open( \*STDOUT, '+>>&', \*STDERR );
+open( \*STDOUT, '+<&', \*STDERR );
+
+#-----------------------------------------------------------------------------
+
+## name no three-arg equivalent passes
+## failures 0
+## cut
+
 # These are actually forks
 open FH, '-|';
 open FH, '|-';
@@ -67,13 +101,6 @@ open FH, '|-';
 open FH, q{-|};
 open FH, qq{-|};
 open FH, "-|";
-
-# Other file modes.
-open( \*STDOUT, '>>&STDERR' );
-open( \*STDOUT, '<&STDERR' );
-open( \*STDOUT, '+>&STDERR' );
-open( \*STDOUT, '+>>&STDERR' );
-open( \*STDOUT, '+<&STDERR' );
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
The documentation claims the two-argument form of open is required "When re-opening STDIN, STDOUT, or STDERR" but I do not believe this is true, the following construct (from http://perldoc.perl.org/functions/open.html) is valid:

`open(OLDERR,     ">&", \*STDERR)`

If there is a construct I have missed which does require two-arg open with I/O handles then please let me know.
