### PR TITLE
Update ProhibitReusedNames to cache canonical vars

### DIFF
--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -6,7 +6,10 @@ use warnings;
 use List::MoreUtils qw(part);
 use Readonly;
 
-use Perl::Critic::Utils qw{ :severities :classification :data_conversion };
+use Perl::Critic::Utils qw<
+    :severities :classification :data_conversion :booleans
+>;
+
 use base 'Perl::Critic::Policy';
 
 our $VERSION = '1.125';
@@ -34,40 +37,62 @@ sub default_themes       { return qw( core bugs )            }
 sub applies_to           { return 'PPI::Statement::Variable' }
 
 #-----------------------------------------------------------------------------
+my %DocumentTree;
+
+sub prepare_to_scan_document {
+    my ($self, $document) = @_;
+
+    %DocumentTree = ();
+
+    return $TRUE;
+}
 
 sub violates {
     my ( $self, $elem, undef ) = @_;
     return if 'local' eq $elem->type;
 
-    my $allow = $self->{_allow};
-    my $names = [ grep { not $allow->{$_} } $elem->variables() ];
-    # Assert: it is impossible for @$names to be empty in valid Perl syntax
-    # But if it IS empty, this code should still work but will be inefficient
+    my @names = grep { !$self->{_allow}{$_}; } $elem->variables();
 
-    # Walk up the PDOM looking for declared variables in the same
-    # scope or outer scopes.  Quit when we hit the root or when we find
-    # violations for all vars (the latter is a shortcut).
-    my $outer = $elem;
-    my @violations;
-    while (1) {
-        my $up = $outer->sprevious_sibling;
-        if (not $up) {
-            $up = $outer->parent;
-            last if !$up; # top of PDOM, we're done
-        }
-        $outer = $up;
+    my $outer = $elem->sprevious_sibling || $elem->parent;
+    return unless ($outer); # top of PDOM, we're done
 
-        if ($outer->isa('PPI::Statement::Variable') && 'local' ne $outer->type) {
-            my %vars = map {$_ => undef} $outer->variables;
-            my $hits;
-            ($hits, $names) = part { exists $vars{$_} ? 0 : 1 } @{$names};
-            if ($hits) {
-                push @violations, map { $self->violation( $DESC . $_, $EXPL, $elem ) } @{$hits};
-                last if not $names;  # found violations for ALL variables, we're done
-            }
-        }
+    my $outerlexicalvars = $self->_get_and_cache_lexical_names($outer);
+
+    my @collisions = grep {$outerlexicalvars->{$_};} @names;
+
+    return my @violations = map { $self->violation( $DESC . $_, $EXPL, $elem ) } @collisions;
+}
+
+# returns hashref - not tying for performance, but shared, so don't modify it
+sub _get_and_cache_lexical_names {
+    my ($self, $elem) = @_;
+
+    no warnings 'recursion';
+
+    my $elemkey = Scalar::Util::refaddr($elem);
+
+    if ($DocumentTree{$elemkey}) {
+        return $DocumentTree{$elemkey};
     }
-    return @violations;
+
+    # walk up the PDOM looking for declared variables in the same
+    # scope or outer scopes quit when we hit the root or when we find
+    # violations for all vars (the latter is a shortcut)
+    my $up = $elem->sprevious_sibling || $elem->parent;
+
+    my %lexicalnames;
+    if ($up) {
+        my $original = $self->_get_and_cache_lexical_names($up);
+        %lexicalnames = %$original;
+    }
+
+    if ($elem->isa('PPI::Statement::Variable') && 'local' ne $elem->type) {
+        my @elemvariables = $elem->variables;
+        @lexicalnames{@elemvariables} = 1 x (@elemvariables);
+    }
+
+    $DocumentTree{$elemkey} = \%lexicalnames;
+    return \%lexicalnames;
 }
 
 1;
@@ -135,14 +160,6 @@ This is intentional, though, because it catches bugs like this:
 
 I've done this myself several times -- it's a strong habit to put that
 "my" in front of variables at the start of subroutines.
-
-
-=head2 Performance
-
-The current implementation walks the tree over and over.  For a big
-file, this can be a huge time sink.  I'm considering rewriting to
-search the document just once for variable declarations and cache the
-tree walking on that single analysis.
 
 
 =head1 CONFIGURATION

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -44,9 +44,9 @@ sub violates {
 
 # modifies $seen_vars
 sub _get_violations_below_element_given_seen_vars {
-	my ( $self, $elem, $seen_vars ) = @_;
-	if (!$elem->isa('PPI::Node')) { return; }
-	my @violations;
+        my ( $self, $elem, $seen_vars ) = @_;
+        if (!$elem->isa('PPI::Node')) { return; }
+        my @violations;
 
         foreach my $child_elem ($elem->schildren) {
                 if ($child_elem->isa('PPI::Statement::Variable') && $child_elem->type ne 'local') {

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -44,7 +44,7 @@ sub violates {
 
 # modifies $seen_vars
 sub _get_violations_below_element_given_seen_vars {
-my ( $self, $elem, $seen_vars ) = @_;
+	my ( $self, $elem, $seen_vars ) = @_;
 	if (!$elem->isa('PPI::Node')) { return; }
 	my @violations;
 

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -46,7 +46,7 @@ sub violates {
 sub _get_violations_below_element_given_seen_vars {
 my ( $self, $elem, $seen_vars ) = @_;
 
-        return unless ($elem->isa('PPI::Node'));
+	unless ($elem->isa('PPI::Node')) { return; }
 
 	my @violations;
 
@@ -61,7 +61,7 @@ my ( $self, $elem, $seen_vars ) = @_;
                 push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
         }
 
-	return @violations;
+        return @violations;
 }
 
 1;

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -3,6 +3,7 @@ package Perl::Critic::Policy::Variables::ProhibitReusedNames;
 use 5.006001;
 use strict;
 use warnings;
+use List::MoreUtils qw(part);
 use Readonly;
 
 use Perl::Critic::Utils qw{ :severities :classification :data_conversion };
@@ -52,10 +53,12 @@ sub _get_violations_below_element_given_seen_vars {
 	foreach my $child_elem ($elem->schildren) {
 	        if ($child_elem->isa('PPI::Statement::Variable') && $child_elem->type ne 'local') {
                     foreach my $var ($child_elem->variables) {
-                            push @violations, $self->violation( $DESC . $var, $EXPL, $child_elem ) if ($seen_vars->{$var}++); # impact shared variable
+                        if (!$self->{_allow}{$var} && $seen_vars->{$var}++) {
+                            push @violations, $self->violation( $DESC . $var, $EXPL, $child_elem );
+                        }
                     }
-            }
-            push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
+                }
+                push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
 	}
 
 	return @violations;
@@ -166,3 +169,4 @@ can be found in the LICENSE file included with this module.
 #   c-indentation-style: bsd
 # End:
 # ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :
+

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -3,12 +3,9 @@ package Perl::Critic::Policy::Variables::ProhibitReusedNames;
 use 5.006001;
 use strict;
 use warnings;
-use List::MoreUtils qw(part);
 use Readonly;
 
-use Perl::Critic::Utils qw<
-    :severities :classification :data_conversion :booleans
->;
+use Perl::Critic::Utils qw{ :severities :classification :data_conversion };
 
 use base 'Perl::Critic::Policy';
 
@@ -57,8 +54,8 @@ sub _get_violations_below_element_given_seen_vars {
                     foreach my $var ($child_elem->variables) {
                             push @violations, $self->violation( $DESC . $var, $EXPL, $child_elem ) if ($seen_vars->{$var}++); # impact shared variable
                     }
-                }
-                push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
+            }
+            push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
 	}
 
 	return @violations;

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -45,9 +45,7 @@ sub violates {
 # modifies $seen_vars
 sub _get_violations_below_element_given_seen_vars {
 my ( $self, $elem, $seen_vars ) = @_;
-
-	unless ($elem->isa('PPI::Node')) { return; }
-
+	if (!$elem->isa('PPI::Node')) { return; }
 	my @violations;
 
         foreach my $child_elem ($elem->schildren) {

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -37,29 +37,29 @@ sub applies_to           { return 'PPI::Document' }
 #-----------------------------------------------------------------------------
 
 sub violates {
-    my ( $self, $elem, $doc ) = @_;
+        my ( $self, $elem, $doc ) = @_;
 
-    return $self->_get_violations_below_element_given_seen_vars($doc, {});
+        return $self->_get_violations_below_element_given_seen_vars($doc, {});
 }
 
 # modifies $seen_vars
-sub _get_violations_below_element_given_seen_vars { 
-	my ( $self, $elem, $seen_vars ) = @_;   
+sub _get_violations_below_element_given_seen_vars {
+my ( $self, $elem, $seen_vars ) = @_;
 
-	return unless ($elem->isa('PPI::Node'));
+        return unless ($elem->isa('PPI::Node'));
 
 	my @violations;
 
-	foreach my $child_elem ($elem->schildren) {
-	        if ($child_elem->isa('PPI::Statement::Variable') && $child_elem->type ne 'local') {
-                    foreach my $var ($child_elem->variables) {
-                        if (!$self->{_allow}{$var} && $seen_vars->{$var}++) {
-                            push @violations, $self->violation( $DESC . $var, $EXPL, $child_elem );
+        foreach my $child_elem ($elem->schildren) {
+                if ($child_elem->isa('PPI::Statement::Variable') && $child_elem->type ne 'local') {
+                        foreach my $var ($child_elem->variables) {
+                                if (!$self->{_allow}{$var} && $seen_vars->{$var}++) {
+                                        push @violations, $self->violation( $DESC . $var, $EXPL, $child_elem );
+                                }
                         }
-                    }
                 }
                 push @violations, $self->_get_violations_below_element_given_seen_vars($child_elem, {%{$seen_vars}});
-	}
+        }
 
 	return @violations;
 }
@@ -169,4 +169,3 @@ can be found in the LICENSE file included with this module.
 #   c-indentation-style: bsd
 # End:
 # ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :
-


### PR DESCRIPTION
As a performance improvement, cache lexical variables as we walk up the pdom.

this commit should fix #385 
