### PR TITLE
Speed up BuiltinFunctions::ProhibitUselessTopic->violates

### DIFF
--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitUselessTopic.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitUselessTopic.pm
@@ -44,7 +44,13 @@ my @topical_funcs = qw(
 );
 my %topical_funcs = map { ($_ => 1) } @topical_funcs;
 
-sub violates {
+my %applies_to;
+@applies_to{ @filetest_operators, @topical_funcs } = ();
+
+sub violates {  ## no critic (ArgUnpacking)
+    # Exit early if the element can't possibly be one we care about.
+    return if not exists $applies_to{ $_[1]->content };
+
     my ( $self, $elem, undef ) = @_;
 
     my $content = $elem->content;


### PR DESCRIPTION
This policy is rather hot as it applies to all token words. Add a short circuiting hash lookup to the start of the method.

A crude benchmark, using CGI.pm as "typical perl source", shows a 7% speedup:

``` perl
use lib 'lib';
use strict;
use warnings;

use Benchmark 'cmpthese';
use Perl::Critic;

my ($perl) = grep -e, map "$_/CGI.pm", @INC;
my $doc    = PPI::Document->new($perl);
my @elems  = @{ $doc->find('PPI::Token::Word') };
my $policy = Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic->new;

cmpthese -3, {
    violates  => sub { $policy->violates($_)  for @elems },
    violates2 => sub { $policy->violates2($_) for @elems },
};
```

```
$ perl bench.pl 
           Rate  violates violates2
violates  174/s        --       -7%
violates2 187/s        7%        --
```
