### PR TITLE
Add missing POD new line between color and colour

### DIFF
--- a/bin/perlcritic
+++ b/bin/perlcritic
@@ -391,6 +391,7 @@ L<http://safari.oreilly.com> instead of page numbers from the actual book.
 NOTE: This feature is not implemented yet.
 
 =item C<--color>
+
 =item C<--colour>
 
 This option is on when outputting to a tty.  When set, Severity 5 and 4 are


### PR DESCRIPTION
For perldoc to display this properly, there needs to be a new line between =item --colour and =item --color