### PR TITLE
make is_class_name handle constant subscripts

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -783,6 +783,7 @@ sub is_class_name {
     return if !$elem;
 
     return _is_dereference_operator( $elem->snext_sibling() )
+        && !eval{$elem->snext_sibling->snext_sibling->isa('PPI::Structure::Subscript')}
         && !_is_dereference_operator( $elem->sprevious_sibling() );
 }
 


### PR DESCRIPTION
Something like

```perl
use Foo;
Foo::Bar->{xyz};
```

wrongly identifies the PPI::Token::Word 'Foo::Bar' as a class name when 'Foo::Bar' is actually a constant hashref (created with the constant pragma.)


this commit should fix that issue.