### PR TITLE
Ignore Perl version specifications in 'force' mode.

### DIFF
--- a/bin/perlcritic
+++ b/bin/perlcritic
@@ -271,9 +271,10 @@ to report.
 
 =item C<--force>
 
-Directs C<perlcritic> to ignore the magical C<"## no critic"> annotations in
-the source code. See L<"BENDING THE RULES"> for more information.  You can set
-the default value for this option in your F<.perlcriticrc> file.
+Directs C<perlcritic> to ignore the magical C<"## no critic"> annotations and
+Perl version specifications in the source code. See L<"BENDING THE RULES"> for
+more information.  You can set the default value for this option in your
+F<.perlcriticrc> file.
 
 =item C<--statistics>
 

--- a/lib/Perl/Critic.pm
+++ b/lib/Perl/Critic.pm
@@ -117,8 +117,12 @@ sub critique {  ## no critic (ArgUnpacking)
 sub _gather_violations {
     my ($self, $doc) = @_;
 
-    # Disable exempt code lines, if desired
-    if ( not $self->config->force() ) {
+    if ( $self->config->force() ) {
+        # Disable processing of the Perl version statements
+        $doc->suppress_version_statements();
+    }
+    else {
+        # Exempt annotated code
         $doc->process_annotations();
     }
 
@@ -383,11 +387,13 @@ L<Perl::Critic::Utils::Constants/"$PROFILE_STRICTNESS_QUIET"> makes
 Perl::Critic shut up about these things.
 
 B<-force> is a boolean value that controls whether Perl::Critic observes the
-magical C<"## no critic"> annotations in your code. If set to a true value,
-Perl::Critic will analyze all code.  If set to a false value (which is the
-default) Perl::Critic will ignore code that is tagged with these annotations.
-See L<"BENDING THE RULES"> for more information.  You can set the default
-value for this option in your F<.perlcriticrc> file.
+magical C<"## no critic"> annotations and Perl version specifications in your
+code. If set to a true value, Perl::Critic will analyze all code.  If set to
+a false value (which is the default) Perl::Critic will ignore code that is
+tagged with C<"## no critic"> annotations and some violations that are
+unavoidable in older versions of Perl. See L<"BENDING THE RULES"> for more
+information.  You can set the default value for this option in your
+F<.perlcriticrc> file.
 
 B<-verbose> can be a positive integer (from 1 to 11), or a literal format
 specification.  See L<Perl::Critic::Violation|Perl::Critic::Violation> for an

--- a/lib/Perl/Critic/Document.pm
+++ b/lib/Perl/Critic/Document.pm
@@ -382,6 +382,14 @@ sub highest_explicit_perl_version {
 
 #-----------------------------------------------------------------------------
 
+sub suppress_version_statements {
+    my ($self) = @_;
+    $self->{_highest_explicit_perl_version} = undef;
+    return;
+}
+
+#-----------------------------------------------------------------------------
+
 sub uses_module {
     my ($self, $module_name) = @_;
 
@@ -800,6 +808,12 @@ Returns a L<version|version> object for the highest Perl version
 requirement declared in the document via a C<use> or C<require>
 statement.  Returns nothing if there is no version statement.
 
+
+=item C<< suppress_version_statements() >>
+
+Causes C<highest_explicit_perl_version> to indicate that no version
+was specified by the document, regardless of the actual Perl version
+requirements that were declared.
 
 =item C<< uses_module($module_or_pragma_name) >>
 

--- a/t/08_document.t
+++ b/t/08_document.t
@@ -15,7 +15,7 @@ use Perl::Critic::Utils::DataConversion qw< dor >;
 
 
 use Test::Deep;
-use Test::More tests => 43;
+use Test::More tests => 50;
 
 #-----------------------------------------------------------------------------
 
@@ -31,6 +31,7 @@ can_ok('Perl::Critic::Document', 'find_any');
 can_ok('Perl::Critic::Document', 'namespaces');
 can_ok('Perl::Critic::Document', 'subdocuments_for_namespace');
 can_ok('Perl::Critic::Document', 'highest_explicit_perl_version');
+can_ok('Perl::Critic::Document', 'suppress_version_statements');
 can_ok('Perl::Critic::Document', 'uses_module');
 can_ok('Perl::Critic::Document', 'ppi_document');
 can_ok('Perl::Critic::Document', 'is_program');
@@ -171,6 +172,13 @@ sub test_version {
         $document->highest_explicit_perl_version(),
         $expected_version,
         qq<Get "$description_version" for "$code".>,
+    );
+
+    $document->suppress_version_statements();
+    is(
+        $document->highest_explicit_perl_version(),
+        undef,
+        qq<Get "undef for "$code" when suppressed.>,
     );
 
     return;


### PR DESCRIPTION
Some policies use the highest explicit Perl version specified
by the code as an indicator for intended backwards compatibility
and do not report violation as a result. This behavior is now
suppressed when running with the 'force' option.