### PR TITLE
make is_class_name handle constant subscripts

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -783,6 +783,7 @@ sub is_class_name {
     return if !$elem;
 
     return _is_dereference_operator( $elem->snext_sibling() )
+        && !eval{$elem->snext_sibling->snext_sibling->isa('PPI::Structure::Subscript')}
         && !_is_dereference_operator( $elem->sprevious_sibling() );
 }
 

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 153;
+use Test::More tests => 155;
 
 #-----------------------------------------------------------------------------
 
@@ -36,6 +36,7 @@ test_is_perl_builtin();
 test_is_perl_global();
 test_precedence_of();
 test_is_subroutine_name();
+test_is_class_name();
 test_policy_long_name_and_policy_short_name();
 test_interpolate();
 test_is_perl_and_shebang_line();
@@ -278,6 +279,35 @@ sub test_is_subroutine_name {
     $doc  = make_doc( $code );
     $word = $doc->find_first( sub { $_[1] eq 'foo' } );
     ok( !is_subroutine_name( $word ), 'Is not a subroutine name');
+
+    return;
+}
+
+#-----------------------------------------------------------------------------
+
+sub test_is_class_name {
+    my $code = <<'EOF';
+        package World::Geography;
+
+        use constant CAPITALS => +{
+            England     => 'London',
+            France      => 'Paris',
+        };
+
+        sub GetCapital {
+            my ($class, $country) = @_;
+            return World::Geography::CAPITALS->{$country};
+        }
+
+        my $paris = World::Geography->GetCapital('France');
+EOF
+
+    my $doc  = make_doc( $code );
+    my $class_word = $doc->find_first( sub { $_[1] eq 'World::Geography' && !is_package_declaration($_[1]) } );
+    my $non_class_word = $doc->find_first( sub { $_[1] eq 'World::Geography::CAPITALS' } );
+
+    ok( is_class_name( $class_word ), 'Is a class name');
+    ok( !is_class_name( $non_class_word ), 'Is not a class name');
 
     return;
 }


### PR DESCRIPTION
Something like

``` perl
use Foo;
Foo::Bar->{xyz};
```

wrongly identifies the PPI::Token::Word 'Foo::Bar' as a class name when 'Foo::Bar' is actually a constant hashref (created with the constant pragma.)

this commit should fix that issue.

re-vamp of #664
