### PR TITLE
Support attr, proto & sig in RequireArgUnpacking

### DIFF
--- a/t/Subroutines/RequireArgUnpacking.run
+++ b/t/Subroutines/RequireArgUnpacking.run
@@ -433,6 +433,38 @@ sub BUILD {
 }
 
 #-----------------------------------------------------------------------------
+
+## name Anonymous subroutine with attributes and/or prototypes
+## failures 0
+## cut
+
+sub foo {
+    my ( $foo ) = @_;
+
+    my $bar;
+
+    # attribute
+    my $baz = sub : lvalue {
+        my ( $b ) = @_;
+        return $b;
+    };
+
+    # prototype
+    my $burfle = sub (@) {};
+
+    # both
+    my $buzz = sub ($) : lvalue {
+        my ( $b ) = @_;
+        return $b;
+    };
+
+    # signature, which PPI 1.220 parses as prototype
+    my $boo = sub ($left, $right) {
+        return $left * $right;
+    }
+}
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
P::C::P::Subroutines::RequireArgUnpacking should not descend into nested
subroutines, since they cause false positives. But it does not attempt
to detect anonymous subroutines with attributes, prototypes, or
signatures. This commit attempts to rectify the situation.
