### PR TITLE
GH #694: Fix internal links from ProhibityStringy* to RequireBlock*

### DIFF
--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringyEval.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringyEval.pm
@@ -154,9 +154,9 @@ L<Perl::Critic::Policy::Lax::ProhibitStringyEval::ExceptForRequire|Perl::Critic:
 
 =head1 SEE ALSO
 
-L<Perl::Critic::Policy::ControlStrucutres::RequireBlockGrep|Perl::Critic::Policy::ControlStrucutres::RequireBlockGrep>
+L<Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep|Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep>
 
-L<Perl::Critic::Policy::ControlStrucutres::RequireBlockMap|Perl::Critic::Policy::ControlStrucutres::RequireBlockMap>
+L<Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap|Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap>
 
 
 =head1 AUTHOR

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringySplit.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitStringySplit.pm
@@ -83,9 +83,9 @@ This Policy is not configurable except for the standard options.
 
 =head1 SEE ALSO
 
-L<Perl::Critic::Policy::ControlStrucutres::RequireBlockGrep|Perl::Critic::Policy::ControlStrucutres::RequireBlockGrep>
+L<Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep|Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep>
 
-L<Perl::Critic::Policy::ControlStrucutres::RequireBlockMap|Perl::Critic::Policy::ControlStrucutres::RequireBlockMap>
+L<Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap|Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap>
 
 
 =head1 AUTHOR


### PR DESCRIPTION
The documentation for Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval
(and ProhibitStringySplit) had bad SEE ALSO links pointing to the wrong
location for Perl::Critic::Policy::BuiltinFunctions::RequreBlockGrep
(and RequireBlockMap)
