### PR TITLE
add color support for 'MSWin32' platforms

### DIFF
--- a/TODO.pod
+++ b/TODO.pod
@@ -190,11 +190,6 @@ Why can't I do this:
     ## use critic (SomeOtherPolicy)
 
 
-=item * Make color work on Windows.
-
-Use L<Win32::Console::ANSI> like L<App::Ack>.
-
-
 =item * Create P::C::Node and make P::C::Document a subclass and make use of PPIx::Utilities::Node::split_ppi_node_by_namespace() to provide per-namespace caching of lookups that are now on P::C::Document.
 
 This is necessary to get P::C::Moose Policies correct.

--- a/bin/perlcritic
+++ b/bin/perlcritic
@@ -396,7 +396,8 @@ NOTE: This feature is not implemented yet.
 
 This option is on when outputting to a tty.  When set, Severity 5 and 4 are
 colored red and yellow, respectively.  Colorization only happens if
-L<Term::ANSIColor> is installed and it only works on non-Windows environments.
+L<Term::ANSIColor> is installed. For Windows environments,
+L<Win32::Console::ANSI> must also be installed.
 Negate this switch to disable color.  You can set the default value for this
 option in your F<.perlcriticrc> file.
 

--- a/lib/Perl/Critic/Command.pm
+++ b/lib/Perl/Critic/Command.pm
@@ -518,7 +518,7 @@ sub _get_option_specification {
 
 sub _colorize_by_severity {
     my @violations = @_;
-    return @violations if _this_is_windows();
+    return @violations if _this_is_windows() && !eval 'require Win32::Console::ANSI; 1';
     return @violations if not eval {
         require Term::ANSIColor;
         Term::ANSIColor->VERSION( $_MODULE_VERSION_TERM_ANSICOLOR );


### PR DESCRIPTION
This is a simple addition that activates color output on 'MSWin32' platforms.

No other code changes are needed.

You may want to add `Win32::Console::ANSI` as an optional/recommended, OS-dependent module.
