### PR TITLE
Fix the tracking of violation lines

### DIFF
--- a/lib/Perl/Critic/Violation.pm
+++ b/lib/Perl/Critic/Violation.pm
@@ -25,12 +25,12 @@ use Perl::Critic::Exception::Fatal::Internal qw< throw_internal >;
 our $VERSION = '1.126';
 
 
+Readonly::Scalar my $NO_EXCEPTION_NO_SPLIT_LIMIT        => -1;
 Readonly::Scalar my $LOCATION_LINE_NUMBER               => 0;
 Readonly::Scalar my $LOCATION_COLUMN_NUMBER             => 1;
 Readonly::Scalar my $LOCATION_VISUAL_COLUMN_NUMBER      => 2;
 Readonly::Scalar my $LOCATION_LOGICAL_LINE_NUMBER       => 3;
 Readonly::Scalar my $LOCATION_LOGICAL_FILENAME          => 4;
-
 
 # Class variables...
 my $format = "%m at line %l, column %c. %e.\n"; # Default stringy format
@@ -297,7 +297,13 @@ sub _line_containing_violation {
     my $code_string = $stmnt->content() || $EMPTY;
 
     # Split into individual lines
-    my @lines = split qr{ \n }xms, $code_string, -1;
+    # From `perldoc -f split`:
+    # If LIMIT is negative, it is treated as if it were instead
+    # arbitrarily large; as many fields as possible are produced.
+    #
+    # If it's omitted, it's the same except trailing empty fields, so we need
+    # without a limit for the split and without an exception
+    my @lines = split qr{ \n }xms, $code_string, $NO_EXCEPTION_NO_SPLIT_LIMIT;
 
     # Take the line containing the element that is in violation
     my $inx = ( $elem->line_number() || 0 ) -

--- a/lib/Perl/Critic/Violation.pm
+++ b/lib/Perl/Critic/Violation.pm
@@ -297,7 +297,7 @@ sub _line_containing_violation {
     my $code_string = $stmnt->content() || $EMPTY;
 
     # Split into individual lines
-    my @lines = split qr{ \n\s* }xms, $code_string;
+    my @lines = split qr{ \n }xms, $code_string, -1;
 
     # Take the line containing the element that is in violation
     my $inx = ( $elem->line_number() || 0 ) -


### PR DESCRIPTION
(I couldn't find an issue relating to this.)

The code that tries to discover on which line a violation occurred uses a regex that accidentally treats multiple newlines as a single line.

Using a policy that tries to detect errors in multiple lines, such as Perl::Critic::Policy::CodeLayout::ProhibitHashBarewords:

  Use of uninitialized value $min_width in numeric gt (>)
      at /usr/local/share/perl/5.18.2/String/Format.pm line 51.

  Use of uninitialized value $replacement in concatenation (.) or string
      at /usr/local/share/perl/5.18.2/String/Format.pm line 67.

The solution is to remove '\s*' and instead make sure we split with a negative third argument in order to preserve the number of consecutive empty lines we encounter.
