### PR TITLE
First shot at contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to Perl::Critic
+
+These are the guidelines for contributing to the Perl::Critic repository.
+
+## Issues
+
+File an issue if you think you've found a bug. Please describe
+
+1. How can it be reproduced
+2. What was expected
+3. What actually occurred
+4. What version of the involved component
+
+## Patches
+
+Patches for fixes, features, and improvements are accepted via pull requests.
+
+Pull requests should be based on the **dev branch**, unless you want to contribute to an active branch for a specific topic.
+
+All contributions are welcome and most will be accepted.
+
+Please see the [developer guidelines](https://github.com/Perl-Critic/Perl-Critic/blob/dev/README.developer) and the complete [developer documentation](https://metacpan.org/pod/Perl::Critic::DEVELOPER).
+
+## Licensing and copyright
+
+Please note that accepted contributions are included in the repository and hence under the same license as the repository contributed to.


### PR DESCRIPTION
It has become a de facto standard for Github repositories to have file containing information on how to contribute to a given repository. 

In relation to issue #709 I thought I would try to come up with a CONTRIBUTING.md for the Perl::Critic repository, please feel free to use this PR.

Another benefit from having t CONTRIBUTING.md in the repository is that it triggers a minor GUI tweak for issues, please see the attached example screenshot.

jonasbn

![710](https://cloud.githubusercontent.com/assets/75423/21471112/6b3f954e-caa5-11e6-84e7-d6ad78bdd77d.png)
