### PR TITLE
Policy::Modules::RequireVersionVar: only modules and libraries should be tested

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireVersionVar.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireVersionVar.pm
@@ -26,6 +26,14 @@ sub applies_to           { return 'PPI::Document'          }
 
 #-----------------------------------------------------------------------------
 
+sub prepare_to_scan_document {
+    my ( $self, $document ) = @_;
+
+    return $document->is_module();   # Must be a library or module.
+}
+
+#-----------------------------------------------------------------------------
+
 sub violates {
     my ( $self, $elem, $doc ) = @_;
 

--- a/t/Modules/RequireVersionVar.run
+++ b/t/Modules/RequireVersionVar.run
@@ -99,6 +99,16 @@ package Foo 0.001;
 
 package Foo;
 
+## name programs are exempt
+## failures 0
+## parms
+## cut
+#!/usr/bin/perl
+my $foo = 42;
+
+#-----------------------------------------------------------------------------
+
+
 ##############################################################################
 # Local Variables:
 #   mode: cperl


### PR DESCRIPTION
Based on similar method and unittest from `Modules::RequireEndWithOne`
Fixes #709 