### PR TITLE
issue #717: Enable sonar reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nytprof*
 t/ControlStructures/ProhibitNegativeExpressionsInUnlessAndUntilConditions.run
 t/NamingConventions/Capitalization.run
 t/Variables/RequireLocalizedPunctuationVars.run
+.sonar/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: perl
+addons:
+  sonarqube:
+    token:
+      secure: "ieDvN/2zbIDwEH6CY7PEYeMwb2bhx6WYpTJuzjZTMiFCeHl6V8813PmgqHNBOyRekg18H3z8PZQFv1MZ5hkWIRgluwAZ3lQnuwJKkGwn2ezEnJDBoZ+Bas58G5TOuIiDgSumg1myFakSNUKOLUPpYgLJBjifyvUIF4EBdCeUYgM="
+  apt:
+    packages:
+      - oracle-java8-set-default
 
 perl:
    - "5.21"
@@ -35,3 +42,6 @@ script:
    - export HARNESS_OPTIONS='j:c'
    - perl Build.PL
    - ./Build authortest
+
+after_success:
+  - 'if [ "$PERLBREW_PERL" == "5.20" ] ; then JAVA_HOME=$JAVA_HOME tools/sonar-report.sh ; fi' # pick any recent perl to run once

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -83,3 +83,7 @@ RCS
 
 # Symlink to lib/Perl/Critic/Policy
 ^Policy
+
+# sonar-scanner script
+tools/sonar-report.sh$
+.sonar/$

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,22 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=Perl-Critic
+# this is the name displayed in the SonarQube UI
+sonar.projectName=Perl::Critic
+# version
+sonar.projectVersion=1.126
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# Since SonarQube 4.2, this property is optional if sonar.modules is set. 
+# If not set, SonarQube starts looking for source code from the directory containing 
+# the sonar-project.properties file.
+sonar.sources=lib
+ 
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+sonar.clover.reportPath=cover_db/clover.xml
+sonar.perl.testHarness.archivePath=_build/testReport.tgz
+sonar.perlcritic.reportPath=_build/perlcritic_report.txt
+sonar.tests=t
+sonar.debug.level=TRACE
+sonar.verbose=true

--- a/tools/sonar-report.sh
+++ b/tools/sonar-report.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e # Exit with nonzero exit code if anything fails
+
+# make sure Devel::Cover::Report::Clover and Perl::Critic are installed locally.
+cpanm --notest Devel::Cover::Report::Clover Perl::Critic
+
+# run tests and generate coverage and TAP report
+HARNESS_OPTIONS="j:c:a_build/testReport.tgz" HARNESS_PERL_SWITCHES="-MDevel::Cover" ./Build test
+
+# extract clover.xml report from cover_db
+cover -report clover
+
+# make sure we map the reported coverage on lib and not blib/lib
+sed -i 's#blib/lib#lib#' cover_db/clover.xml
+
+# self-critique with "core" theme
+perlcritic --gentle --theme core --quiet --verbose "%f~|~%s~|~%l~|~%c~|~%m~|~%e~|~%p~||~%n" lib t > _build/perlcritic_report.txt || true
+
+# upload to sonarqube
+sonar-scanner -Dsonar.host.url=http://sonarqube.racodond.com/ -Dsonar.login=$SONAR_TOKEN


### PR DESCRIPTION
Ran locally and initially created Perl-Critic project on this address: http://sonarqube.racodond.com/dashboard?id=Perl-Critic

Another thing: When I configured the travis scripts on my project, I had to enable 'sudo required', otherwise there was no way to get java8 installed. Your mileage may vary, but if after merging the sonar-scanner complains with wrong class-file format, that would mean it's run with java7. In that case, we would have to switch to 'sudo required' as well. 
