### PR TITLE
add AppVeyor testing config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,31 @@
+# .appveyor.yml
+
+# * note: AppVeyor setup
+# 1. add an AppVeyor project observing the repository
+# 2. set "General / Custom configuration .yml file name" = ".appveyor.yml" within the project SETTINGS
+# 3. enable "General / Skip branches without appveyor.yml" within the project SETTINGS
+
+skip_tags: true
+
+cache:
+  - C:\strawberry -> .appveyor.yml
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl -y
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+  - cpanm --installdeps .
+
+build_script:
+  - perl Build.PL
+
+test_script:
+  - Build test
+
+# notifications:
+# To get Github PR notifications from AppVeyor, get an auth token from Github,
+# encrypt it at https://ci.appveyor.com/tools/encrypt and put it into the
+# secure field
+#  - provider: GitHubPullRequest
+#    auth_token:
+#      secure: ...


### PR DESCRIPTION
This adds the needed configuration information to allow AppVeyor to test the project.

A working AppVeyor project testing this branch can be seen at https://ci.appveyor.com/project/rivy/perl-perl-critic .

A "Perl-Critic" account, on AppVeyor, observing this repo will need to be setup to complete the testing setup. Instructions for correct setup are within the notes at the top of the added `.appveyor.yml` file.