### PR TITLE
Accept Test2::Bundle::Extended as "use strict" equivalent

### DIFF
--- a/lib/Perl/Critic/Utils/Constants.pm
+++ b/lib/Perl/Critic/Utils/Constants.pm
@@ -123,6 +123,8 @@ Readonly::Array our @STRICT_EQUIVALENT_MODULES => qw(
     sane
     shit
     strictures
+
+    Test2::Bundle::Extended
 );
 
 # Such modules tend to inflict both strictures and warnings, so for


### PR DESCRIPTION
According to https://metacpan.org/pod/Test2::Bundle::Extended#PRAGMAS, Test2::Bundle::Extended turns on strict