### PR TITLE
remove Modules::RequireBarewordIncludes test with invalid syntax (this blocks PPI atm)

### DIFF
--- a/t/Modules/RequireBarewordIncludes.run
+++ b/t/Modules/RequireBarewordIncludes.run
@@ -14,12 +14,11 @@ is( pcritique($policy, \$code), 0, $policy);
 #-----------------------------------------------------------------------------
 
 ## name basic failures
-## failures 6
+## failures 5
 ## cut
 require 'Exporter';
 require 'My/Module.pl';
 use 'SomeModule';
-use q{OtherModule.pm};
 no "Module";
 no "Module.pm";
 


### PR DESCRIPTION
I'm working on a new PPI release and found a small test-related bug in Perl::Critic, wherein a test expects PPI to misinterpret invalid Perl syntax.

This patch removes said test.

```
D:\cpan\PPI>perl -Ilib -e "use q{PPI.pm};"
Can't locate q.pm in @INC (you may need to install the q module) (@INC contains: lib C:/strawberry/perl/site/lib/MSWin32-x86-multi-thread-64int C:/strawberry/perl/site/lib C:/strawberry/perl/vendor/lib C:/strawberry/perl/lib .) at -e line 1.
BEGIN failed--compilation aborted at -e line 1.

D:\cpan\PPI>perl -Ilib -e "use strict; use q{PPI.pm};"
Bareword "PPI" not allowed while "strict subs" in use at -e line 1.
Bareword "pm" not allowed while "strict subs" in use at -e line 1.
Execution of -e aborted due to compilation errors.
```