### PR TITLE
Add capture array

### DIFF
--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
@@ -25,8 +25,10 @@ Readonly::Scalar my $WHILE => q{while};
 
 Readonly::Hash my %ZERO_BASED_CAPTURE_REFERENCE =>
     hashify( qw< ${^CAPTURE} > );
+# TODO: additional logic to prevent ${^CAPTURE_ALL}[n] from being recognized
+# as a use of capture variable n.
 Readonly::Hash my %CAPTURE_REFERENCE => (
-    hashify( qw< $+ $- > ),
+    hashify( qw< $+ $- ${^CAPTURE_ALL} > ),
     %ZERO_BASED_CAPTURE_REFERENCE );
 Readonly::Hash my %CAPTURE_REFERENCE_ENGLISH => (
     hashify( qw{ $LAST_PAREN_MATCH $LAST_MATCH_START $LAST_MATCH_END } ),

--- a/t/RegularExpressions/ProhibitUnusedCapture.run
+++ b/t/RegularExpressions/ProhibitUnusedCapture.run
@@ -584,6 +584,27 @@ if ( m/(quoted CAPTURE array element)/ ) {
 
 #-----------------------------------------------------------------------------
 
+## name %{^CAPTURE_ALL} added in 5.25.7
+## failures 0
+## cut
+
+if ( m/(?<x>CAPTURE_ALL)/ ) {
+    print ${^CAPTURE_ALL}{x};
+}
+
+#-----------------------------------------------------------------------------
+
+## name ${^CAPTURE_ALL}[1] has nothing to do with captures
+## failures 1
+## TODO ${^CAPTURE_ALL}[1] has nothing to do with captures
+## cut
+
+if ( m/(CAPTURE_ALL)/ ) {
+    print ${^CAPTURE_ALL}[1];
+}
+
+#-----------------------------------------------------------------------------
+
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4

--- a/t/RegularExpressions/ProhibitUnusedCapture.run
+++ b/t/RegularExpressions/ProhibitUnusedCapture.run
@@ -563,6 +563,27 @@ s/(.)/ { $1 } /e;
 
 #-----------------------------------------------------------------------------
 
+## name @{^CAPTURE} added in 5.25.7 (GitHub #778)
+## failures 0
+## cut
+
+if ( m/(CAPTURE array)/ ) {
+    print @{^CAPTURE};
+}
+
+if ( m/(quoted CAPTURE array)/ ) {
+    print "@{^CAPTURE}\n";
+
+if ( m/(CAPTURE array element)/ ) {
+    print ${^CAPTURE}[0];
+}
+
+if ( m/(quoted CAPTURE array element)/ ) {
+    print "${^CAPTURE}[0]\n";
+}
+
+#-----------------------------------------------------------------------------
+
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
This pull request implements GitHub #778. Collateral changes include support for `%{^CHANGES_ALL}` (implemented the same time as `@{^CHANGES}`) and (for consistency's sake) the recognition of `@-` and `@+` as using all numbered captures.