### PR TITLE
ProhibitLeadingZeros: add exception for POSIX::mkfifo (#786)

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitLeadingZeros.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitLeadingZeros.pm
@@ -43,6 +43,7 @@ sub violates {
     return $self->_create_violation($elem) if $self->{_strict};
     return if $self->_is_first_argument_of_chmod_or_umask($elem);
     return if $self->_is_second_argument_of_mkdir($elem);
+    return if $self->_is_second_argument_of_mkfifo($elem);
     return if $self->_is_third_argument_of_dbmopen($elem);
     return if $self->_is_fourth_argument_of_sysopen($elem);
     return $self->_create_violation($elem);
@@ -86,6 +87,27 @@ sub _is_second_argument_of_mkdir {
     return if not $previous_token;
 
     return $previous_token->content() eq 'mkdir';
+}
+
+sub _is_second_argument_of_mkfifo {
+    my ($self, $elem) = @_;
+
+    # Preceding comma.
+    my $previous_token = _previous_token_that_isnt_a_parenthesis($elem);
+    return if not $previous_token;
+    return if $previous_token->content() ne $COMMA;  # Don't know what it is.
+
+    # FIFO name.
+    $previous_token =
+        _previous_token_that_isnt_a_parenthesis($previous_token);
+    return if not $previous_token;
+
+    $previous_token =
+        _previous_token_that_isnt_a_parenthesis($previous_token);
+    return if not $previous_token;
+
+    return $previous_token->content() eq 'mkfifo'
+        || $previous_token->content() eq 'POSIX::mkfifo';
 }
 
 sub _is_third_argument_of_dbmopen {
@@ -210,6 +232,10 @@ you really want, its better to use C<oct> and make it obvious.
     mkdir $directory, 0755;                         # ok by default
     sysopen $filehandle, $filename, O_RDWR, 0666;   # ok by default
     umask 0002;                                     # ok by default
+
+    use POSIX 'mkfifo';
+    mkfifo $fifo, 0600;                             # ok by default
+    POSIX::mkfifo $fifo, 0600;                      # ok by default
 
 =head1 CONFIGURATION
 

--- a/t/ValuesAndExpressions/ProhibitLeadingZeros.run
+++ b/t/ValuesAndExpressions/ProhibitLeadingZeros.run
@@ -149,6 +149,29 @@ umask ( 002 );
 umask 002;
 umask ( 002 );
 
+## name mkfifo
+## failures 0
+## cut
+
+use POSIX qw(mkfifo);
+POSIX::mkfifo $fifo, 0700;
+POSIX::mkfifo ( $fifo, 0700 );
+mkfifo $fifo, 0700;
+mkfifo ( $fifo, 0700 );
+
+#-----------------------------------------------------------------------------
+
+## name mkdir with strict option
+## failures 4
+## parms { strict => 1 }
+## cut
+
+use POSIX qw(mkfifo);
+POSIX::mkfifo $fifo, 0700;
+POSIX::mkfifo ( $fifo, 0700 );
+mkfifo $fifo, 0700;
+mkfifo ( $fifo, 0700 );
+
 #-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl


### PR DESCRIPTION
This is pretty much copy-and-pasted code from the handling for `mkdir`, except we also ignore the fully-qualified name. The new tests fail before the update and pass afterwards, as do the (same) command line calls:

```bash
$ echo 'use strict; require POSIX; POSIX::mkfifo( $path, 0700 )' | perlcritic
Integer with leading zeros: "0700" at line 1, column 50.  See page 58 of PBP.  (Severity: 5)

$ echo 'use strict; use POSIX qw(mkfifo); mkfifo( $path, 0700 )' | perlcritic
Integer with leading zeros: "0700" at line 1, column 50.  See page 58 of PBP.  (Severity: 5)
```

```bash
$ echo 'use strict; require POSIX; POSIX::mkfifo( $path, 0700 )' | perlcritic
source OK

$ echo 'use strict; use POSIX qw(mkfifo); mkfifo( $path, 0700 )' | perlcritic
source OK
```