### PR TITLE
Fix scope calculation

### DIFF
--- a/lib/Perl/Critic/Document.pm
+++ b/lib/Perl/Critic/Document.pm
@@ -16,7 +16,7 @@ use PPIx::Utilities::Node qw< split_ppi_node_by_namespace >;
 
 use Perl::Critic::Annotation;
 use Perl::Critic::Exception::Parse qw< throw_parse >;
-use Perl::Critic::Utils qw< :booleans :characters shebang_line >;
+use Perl::Critic::Utils qw< :booleans :characters hashify shebang_line >;
 
 use PPIx::Regexp 0.010 qw< >;
 
@@ -318,6 +318,16 @@ sub element_is_in_lexical_scope_after_statement_containing {
 
     my $parent = $stmt;
     while ( ! $parent->scope() ) {
+        # Things appearing in the right-hand side of a
+        # PPI::Statement::Variable are not in-scope to its left-hand
+        # side. RESTRICTION -- this code does not handle truly
+        # pathological stuff like
+        # my ( $c, $d ) = qw{ e f };
+        # my ( $a, $b ) = my ( $c, $d ) = ( $c, $d );
+        _inner_is_defined_by_outer( $inner_elem, $parent )
+            and _location_is_in_right_hand_side_of_assignment(
+                $parent, $inner_elem )
+            and return;
         $parent = $parent->parent()
             or return;
     }
@@ -327,6 +337,19 @@ sub element_is_in_lexical_scope_after_statement_containing {
 
     return $inner_elem->descendant_of( $parent );
 
+}
+
+# Helper for element_is_in_lexical_scope_after_statement_containing().
+# Return true if and only if $outer_elem is a statement that defines
+# variables and $inner_elem is actually a variable defined in that
+# statement.
+sub _inner_is_defined_by_outer {
+    my ( $inner_elem, $outer_elem ) = @_;
+    $outer_elem->isa( 'PPI::Statement::Variable' )
+        and $inner_elem->isa( 'PPI::Token::Symbol' )
+        or return;
+    my %defines = hashify( $outer_elem->variables() );
+    return $defines{$inner_elem->symbol()};
 }
 
 # Helper for element_is_in_lexical_scope_after_statement_containing().
@@ -356,6 +379,33 @@ sub _inner_element_is_in_outer_scope_really {
         }
     }
     return $TRUE;
+}
+
+# Helper for element_is_in_lexical_scope_after_statement_containing().
+# Given and element that represents an assignment or assignment-ish
+# statement, and a location, return true if the location is to the right
+# of the equals sign, and false otherwise (including the case where
+# there is no equals sign). Only the leftmost equals is considered. This
+# is a restriction.
+sub _location_is_in_right_hand_side_of_assignment {
+    my ( $elem, $inner_elem ) = @_;
+    my $inner_loc = $inner_elem->location();
+    my $kid = $elem->schild( 0 );
+    while ( $kid ) {
+        $kid->isa( 'PPI::Token::Operator' )
+            and q{=} eq $kid->content()
+            or next;
+        my $l = $kid->location();
+        $l->[0] > $inner_loc->[0]
+            and return;
+        $l->[0] == $inner_loc->[0]
+            and $l->[1] >= $inner_loc->[1]
+            and return;
+        return $inner_elem->descendant_of( $elem );
+    } continue {
+        $kid = $kid->snext_sibling();
+    }
+    return;
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/Perl/Critic/Document.pm
+++ b/lib/Perl/Critic/Document.pm
@@ -290,8 +290,12 @@ sub element_is_in_lexical_scope_after_statement_containing {
 
     my $stmt = $outer_elem->statement()
         or return;
-    my $last_elem = $stmt->last_element()
-        or return;
+
+    my $last_elem = $stmt;
+    while ( $last_elem->isa( 'PPI::Node' ) ) {
+        $last_elem = $last_elem->last_element()
+            or return;
+    }
 
     my $stmt_loc = $last_elem->location()
         or return;
@@ -302,7 +306,7 @@ sub element_is_in_lexical_scope_after_statement_containing {
     $stmt_loc->[0] > $inner_loc->[0]
         and return;
     $stmt_loc->[0] == $inner_loc->[0]
-        and $stmt_loc->[1] > $inner_loc->[1]
+        and $stmt_loc->[1] >= $inner_loc->[1]
         and return;
 
     # Since we know the inner element is after the outer element, find


### PR DESCRIPTION
This pull request addresses some problems with the Perl::Critic::Document method element_is_in_lexical_scope_after_statement_containing(). Specifically:

* There is a fencepost error in trying to determine if the two elements are in the same statement;

* The list of the for() and foreach() builtins is not in-scope to the iteration variable;

* The right-hand side of a 'my' with assignment is not in-scope to its left-hand side.

This is a public method, but in all of CPAN as of a couple days ago there were only two uses: in Perl::Critic::Document itself to figure out what the default regexp qualifiers are, and in standalone policy Variables::ProhibitUnusedVarsStricter. Perl::ToPerl6::Document has a same-named method that appears to be a cut-and-paste of an earlier version of the method being patched.

Because this method has no tests specific to it, I regression-tested the changes by running Variables::ProhibitUnusedVarsStricter against CPAN, using both old and new versions of this method. The output contained about 500 difference sections, a few of which comprised multiple lines of test failures. I have only reviewed the first 102 differences, and the scorecard is:

False negative in old code.                -    4
False positive in new code. PPI mis-parse. -    5
False positive in new code. Policy error.  -    1
False positive in old code.                -   92

The false positives in the new code are generally the result of PPI thinking that all uses of the symbol are in a part of the code no longer in scope. About half of these represent code that does not compile, and the others are pathological (to me, at least) in other ways leading to a PPI mis-parse. The policy error is the value returned by an lvalue subroutine which does not use a 'return' statement. I'm not sure what to do about it, but if someone complains to you about it, please pass it to me, because it will have to be fixed in ProhibitUnusedVarsStricter if anywhere.

The following is context on how the code got the way it is.

Method element_is_in_lexical_scope_after_statement_containing() was written by me when I was active as part of the Perl::Critic team and trying to come up with a version of core policy Variables::ProhibitUnusedVariables that was more stringent. The long-named method was hung on Perl::Critic::Document because I anticipated it being useful for other things (true), and because I thought some caching might be needed for better performance (false, so far).