### PR TITLE
Do not try to use policy modules without a new() method

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -246,6 +246,7 @@ t/09_theme.t
 t/10_user_profile.t
 t/11_policy_factory.t
 t/12_policy_listing.t
+t/12_policy_without_new.t
 t/12_theme_listing.t
 t/13_bundled_policies.t
 t/14_policy_parameter_behavior_boolean.t
@@ -265,6 +266,7 @@ t/20_policy_prohibit_trailing_whitespace.t
 t/20_policy_require_consistent_newlines.t
 t/20_policy_require_tidy_code.t
 t/92_memory_leaks.t
+t/bad_module/Perl/Critic/Policy/BogusPolicyNoNew.pm
 t/BuiltinFunctions/ProhibitBooleanGrep.run
 t/BuiltinFunctions/ProhibitComplexMappings.run
 t/BuiltinFunctions/ProhibitLvalueSubstr.run

--- a/lib/Perl/Critic/PolicyFactory.pm
+++ b/lib/Perl/Critic/PolicyFactory.pm
@@ -51,7 +51,7 @@ sub import {
             require Module::Pluggable;
             Module::Pluggable->import(search_path => $POLICY_NAMESPACE,
                                       require => 1, inner => 0);
-            @site_policy_names = plugins(); #Exported by Module::Pluggable
+            @site_policy_names = grep { $_->can('new') } plugins(); #Exported by Module::Pluggable
             1;
         };
 

--- a/t/12_policy_without_new.t
+++ b/t/12_policy_without_new.t
@@ -1,0 +1,40 @@
+#!perl
+
+use 5.006001;
+use strict;
+use warnings;
+
+use Test::More;
+
+our $VERSION = '1.131_01';
+use lib 't/bad_module';
+
+BEGIN: {
+    package Perl::Critic::Policy::BogusPolicyNotNew;
+    our $VERSION = '0.1';
+    sub g { return "GOOD"; }
+    1;
+}
+
+use Perl::Critic::TestUtils;
+Perl::Critic::TestUtils::assert_version( $VERSION );
+
+plan( tests => 1 );
+
+use Perl::Critic::PolicyFactory (-test => 1);
+
+my @policy_names = Perl::Critic::PolicyFactory::site_policy_names();
+
+my $badpolicy = grep { m/^Perl::Critic::Policy::BogusPolicyNoNew$/s } @policy_names;
+is($badpolicy, 0, "site_policy_names excludes modules without new() function");
+
+
+#-----------------------------------------------------------------------------
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :

--- a/t/bad_module/Perl/Critic/Policy/BogusPolicyNoNew.pm
+++ b/t/bad_module/Perl/Critic/Policy/BogusPolicyNoNew.pm
@@ -1,0 +1,18 @@
+#!perl
+
+package Perl::Critic::Policy::BogusPolicyNoNew;
+use strict;
+
+our $VERSION = '0.2';
+
+1;
+
+##############################################################################
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :


### PR DESCRIPTION
A little history - I got some errors in my module's smoke tests:

http://matrix.cpantesters.org/?dist=Perl-Critic-Policy-BadStrings%200.100-TRIAL

The errors pointed to Perl::Critic::Policy::ProhibitSmartmatch , which was also installed on the smoke testing boxes that failed.

I was able to duplicate this manually by doing a "cpan install Perl::Critic::Policy::ProhibitSmartmatch" and then trying to use "perlcritic" from the command line using my default configuration.  Sure enough, perlcritic couldn't run and gave the following error:

Perl::Critic::PolicyFactory::_handle_policy_instantiation_exception('Perl::Critic::Policy::ProhibitSmartmatch', undef, 'Can\'t locate object method "new" via package "Perl::Critic::Policy::ProhibitSmartmatch" at /home/jmaslak/perl5/perlbrew/perls/perl-5.26.0/lib/site_perl/5.26.0/Perl/Critic/PolicyFactory.pm line 253.^J') called at /home/jmaslak/perl5/perlbrew/perls/perl-5.26.0/lib/site_perl/5.26.0/Perl/Critic/PolicyFactory.pm line 254

The ProhibitSmartmatch module turns out to basically only be documentation - just POD, no actual implementation (that's done in two other policy modules).

While I think the best fix is to get ProhibitSmartmatch fixed (I've put in a pull request for it that is an ugly hack, but at least gets past that problem). I also think that Perl::Critic can be a bit more tolerant of this type of empty module, and have made a one-line enhancement in this PR (if it doesn't have a new() function, don't include the module in the list of modules created at import time by PolicyFactory).

I'm glad to go a different direction if you would like on this, just let me know what you would like to do.  I've also included a test to validate this fix (and a module under the t/ directory that exhibits similar behavior to ProhibitSmartmatch).

Thanks in advance,
Joelle Maslak