### PR TITLE
Fixed Perl::Critic::Policy::Variables::ProhibitUnusedVariables false positive for variables used in interpolation

### DIFF
--- a/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
@@ -8,6 +8,7 @@ use Readonly;
 use List::MoreUtils qw< any >;
 
 use PPI::Token::Symbol;
+use PPIx::QuoteLike;
 
 use Perl::Critic::Utils qw< :characters :severities >;
 use base 'Perl::Critic::Policy';
@@ -75,6 +76,25 @@ sub _get_symbol_usage {
 
     foreach my $symbol ( @{$symbols} ) {
         $symbol_usage->{ $symbol->symbol() }++;
+    }
+
+    foreach my $class ( qw{
+        PPI::Token::Quote::Double
+        PPI::Token::Quote::Interpolate
+        PPI::Token::QuoteLike::Backtick
+        PPI::Token::QuoteLike::Command
+        PPI::Token::QuoteLike::Readline
+        PPI::Token::HereDoc
+        } ) {
+        foreach my $double_quotish (
+            @{ $document->find( $class ) || [] }
+        ) {
+            my $str = PPIx::QuoteLike->new( $double_quotish )
+                or next;
+            foreach my $var ( $str->variables() ) {
+                $symbol_usage->{ $var }++;
+            }
+        }
     }
 
     return;

--- a/t/Variables/ProhibitUnusedVariables.run
+++ b/t/Variables/ProhibitUnusedVariables.run
@@ -161,6 +161,24 @@ my %foo;
 m/ (?{ $foo{bar} }) /smx;
 
 #-----------------------------------------------------------------------------
+
+## name open a file handle and us in a readline operator
+## failures 0
+## cut
+
+open(my $foo, '<', '/etc/motd') or die;
+my $line = <$foo>;
+
+#-----------------------------------------------------------------------------
+
+## name Interpulating a variable is detected as a usage
+## failures 0
+## cut
+
+my $foo;
+print "Interpulating variable: $foo";
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
Fixed Perl::Critic::Policy::Variables::ProhibitUnusedVariables giving false-positives for variables used in interpolation

This PR uses a new dependency PPIx::QuoteLike to detect variables used inside quote-like tokens.

Also added two tests for example.