### PR TITLE
Allow numeric operators on special number strings 'NaN' and 'inf'

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
@@ -39,7 +39,7 @@ Readonly::Hash my %OPERATOR_TYPES => (
         qw< eq ne lt gt le ge . .= >,
 );
 
-Readonly::Scalar my $TOKEN_COMPATIBILITY_SPECIAL_STRING_OPERATOR => '+';
+Readonly::Scalar my $TOKEN_COMPATIBILITY_SPECIAL_STRING_OPERATOR => qw{+};
 Readonly::Hash my %SPECIAL_STRING_VALUES => (
     map { $_ => 1}
         qw('nan' 'inf' '-inf' '+inf')
@@ -165,7 +165,7 @@ sub _is_special_string_number_addion {
 
     return 1 if $elem_operator
         &&  $elem_operator eq $TOKEN_COMPATIBILITY_SPECIAL_STRING_OPERATOR
-        &&  $SPECIAL_STRING_VALUES{lc($element_1->content()//'')}
+        &&  $SPECIAL_STRING_VALUES{lc($element_1->content()//0)}
         &&  $element_2->isa('PPI::Token::Number')
         &&  $element_2->content() == 0;
     return 1 if !$check_recursive && $self->_is_special_string_number_addion($elem_operator, $element_2, $element_1, 1);

--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
@@ -170,6 +170,7 @@ sub _is_special_string_number_addion {
         &&  $element_2->content() == 0;
     return 1 if !$check_recursive && $self->_is_special_string_number_addion($elem_operator, $element_2, $element_1, 1);
 
+    return;
 }
 
 1;

--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitMismatchedOperators.pm
@@ -215,6 +215,12 @@ warns you about using mismatched operators at run-time.  This Policy
 does essentially the same thing, but at author-time.  That way, you
 can find out about them sooner.
 
+Perl handles the strings 'NaN' and 'inf' as special numbers and creates an NV struct when compared with a numeric operator.
+Although not necessary it is allowed to write code such as:
+    my $i = 'inf'+0;
+This pattern helps others understand that the variable is indeed the Infinite or NaN numbers as Perl interpets them.
+Only these two special string numbers are allowed to have the '+' operator which would otherwise be allowed only for strings.
+
 
 =head1 AUTHOR
 

--- a/t/ValuesAndExpressions/ProhibitMismatchedOperators.run
+++ b/t/ValuesAndExpressions/ProhibitMismatchedOperators.run
@@ -115,6 +115,28 @@ $a .= 1;
 -A 'file' eq "1";
 
 #-----------------------------------------------------------------------------
+
+## name Allow adding zero to special string numbers ('inf' and 'NaN')
+## failures 0
+## cut
+
+my $i = 'NaN'+0;
+$i = 0+'Nan';
+$i = 'inf'+0;
+$i = 0+'inf';
+$i = '-inf'+0;
+$i = '+inf'+0;
+
+#-----------------------------------------------------------------------------
+
+## name Does not allow adding non-zero to special string numbers ('inf' and 'NaN')
+## failures 2
+## cut
+
+my $i = 'NaN'+1;
+$i = 'inf'+2;
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
Policy Perl::Critic::Policy::ValuesAndExpressions::ProhibitMismatchedOperators

It is a common pattern to use 'inf'+0 to numify special strings
This PR allows to add only zeros to the special number strings 'NaN' and 'inf'

It is implemented as a special case so please let me know if you have any comments or ideas on how to achieve this in a different way :) 