### PR TITLE
Assume the .psgi file extension belongs to perl

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -1132,6 +1132,7 @@ sub _is_perl {
     #Check filename extensions
     return 1 if $file =~ m{ [.] PL    \z}xms;
     return 1 if $file =~ m{ [.] p[lm] \z}xms;
+    return 1 if $file =~ m{ [.] psgi  \z}xms;
     return 1 if $file =~ m{ [.] t     \z}xms;
 
     #Check for shebang

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -1710,7 +1710,7 @@ A Perl code file is:
 
 =over
 
-=item * Any file that ends in F<.PL>, F<.pl>, F<.pm>, or F<.t>
+=item * Any file that ends in F<.PL>, F<.pl>, F<.pm>, F<.psgi>, or F<.t>
 
 =item * Any file that has a first line with a shebang containing 'perl'
 

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 153;
+use Test::More tests => 155;
 
 our $VERSION = '1.131_01';
 
@@ -306,11 +306,11 @@ sub test_interpolate {
 #-----------------------------------------------------------------------------
 
 sub test_is_perl_and_shebang_line {
-    for ( qw(foo.t foo.pm foo.pl foo.PL) ) {
+    for ( qw(foo.t foo.pm foo.pl foo.PL foo.psgi) ) {
         ok( Perl::Critic::Utils::_is_perl($_), qq{Is perl: '$_'} );
     }
 
-    for ( qw(foo.doc foo.txt foo.conf foo) ) {
+    for ( qw(foo.doc foo.txt foo.conf foo foo.pl.exe) ) {
         ok( ! Perl::Critic::Utils::_is_perl($_), qq{Is not perl: '$_'} );
     }
 

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 155;
+use Test::More tests => 156;
 
 our $VERSION = '1.131_01';
 
@@ -310,7 +310,7 @@ sub test_is_perl_and_shebang_line {
         ok( Perl::Critic::Utils::_is_perl($_), qq{Is perl: '$_'} );
     }
 
-    for ( qw(foo.doc foo.txt foo.conf foo foo.pl.exe) ) {
+    for ( qw(foo.doc foo.txt foo.conf foo foo.pl.exe foo_pl) ) {
         ok( ! Perl::Critic::Utils::_is_perl($_), qq{Is not perl: '$_'} );
     }
 


### PR DESCRIPTION
This will help Test::Perl::Critic automatically treat PSGI scripts as perl when they lack a shebang line.