### PR TITLE
Add possibility to ignore $self or $class to ProhibitManyArgs

### DIFF
--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
@@ -36,6 +36,12 @@ sub supported_parameters {
             behavior        => 'integer',
             integer_minimum => 1,
         },
+        {
+            name            => 'skip_object',
+            description     => q[Don't count $self or $class first argument],
+            default_string  => '0',
+            behavior        => 'boolean',
+        },
     );
 }
 
@@ -57,7 +63,7 @@ sub violates {
         $prototype =~ s/ \\ [[] .*? []] /*/smxg;    # Allow for grouping
         $num_args = $prototype =~ tr/$@%&*_+/$@%&*_+/;    # RT 56627
     } else {
-       $num_args = _count_args($elem->block->schildren);
+       $num_args = _count_args($self->{_skip_object}, $elem->block->schildren);
     }
 
     if ($self->{_max_arguments} < $num_args) {
@@ -67,7 +73,7 @@ sub violates {
 }
 
 sub _count_args {
-    my @statements = @_;
+    my ($skip_object, @statements) = @_;
 
     # look for these patterns:
     #    " ... = @_;"    => then examine previous variable list
@@ -90,16 +96,17 @@ sub _count_args {
     return 0 if q{=} ne $operator->content();
 
     if ($operand->isa('PPI::Token::Magic') && $AT_ARG eq $operand->content()) {
-       return _count_list_elements(@elements);
+       return _count_list_elements($skip_object, @elements);
     } elsif ($operand->isa('PPI::Token::Word') && 'shift' eq $operand->content()) {
-       return 1 + _count_args(@statements);
+       my $count_first = $skip_object ? !_is_object_arg(pop @elements) : 1;
+       return $count_first + _count_args(0, @statements);  # only check for object on first argument
     }
 
     return 0;
 }
 
 sub _count_list_elements {
-   my @elements = @_;
+   my ($skip_object, @elements) = @_;
 
    my $list = pop @elements;
    return 0 if !$list;
@@ -108,7 +115,20 @@ sub _count_list_elements {
    if (1 == @inner && $inner[0]->isa('PPI::Statement::Expression')) {
       @inner = $inner[0]->schildren;
    }
-   return scalar split_nodes_on_comma(@inner);
+   my @args = split_nodes_on_comma(@inner);
+   return scalar @args if !$skip_object || !@args;;
+
+   # Check if first argument is $self/$class
+   my $first_ref = $args[0];
+   return scalar @args if scalar @{ $first_ref } != 1;  # more complex than simple scalar
+   return scalar @args - !!_is_object_arg($first_ref->[0]);
+}
+
+sub _is_object_arg {
+   my ($symbol) = @_;
+   return if !$symbol;
+   return if !$symbol->isa('PPI::Token::Symbol');
+   return '$self' eq $symbol->content() || '$class' eq $symbol->content();
 }
 
 1;
@@ -150,6 +170,11 @@ this:
   [Subroutines::ProhibitManyArgs]
   max_arguments = 6
 
+To ignore $self or $class as first argument use:
+
+  [Subroutines::ProhibitManyArgs]
+  skip_object = 1
+
 
 =head1 CAVEATS
 
@@ -158,11 +183,6 @@ those.  This should just work when PPI gains that feature.
 
 We don't check for C<@ARG>, the alias for C<@_> from English.pm.
 That's deprecated anyway.
-
-
-=head1 TO DO
-
-Don't include C<$self> and C<$class> in the count.
 
 
 =head1 CREDITS

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
@@ -18,8 +18,10 @@ our $VERSION = '1.131_02';
 
 #-----------------------------------------------------------------------------
 
-Readonly::Scalar my $AT => q{@};
-Readonly::Scalar my $AT_ARG => q{@_}; ## no critic (InterpolationOfMetachars)
+Readonly::Scalar my $AT     => q{@};
+Readonly::Scalar my $AT_ARG => q{@_};     ## no critic (InterpolationOfMetachars)
+Readonly::Scalar my $CLASS  => q{$class}; ## no critic (InterpolationOfMetachars)
+Readonly::Scalar my $SELF   => q{$self};  ## no critic (InterpolationOfMetachars)
 
 Readonly::Scalar my $DESC => q{Too many arguments};
 Readonly::Scalar my $EXPL => [182];
@@ -38,7 +40,7 @@ sub supported_parameters {
         },
         {
             name            => 'skip_object',
-            description     => q[Don't count $self or $class first argument],
+            description     => q[Don't count $self or $class first argument], ## no critic (InterpolationOfMetachars)
             default_string  => '0',
             behavior        => 'boolean',
         },
@@ -128,7 +130,7 @@ sub _is_object_arg {
    my ($symbol) = @_;
    return if !$symbol;
    return if !$symbol->isa('PPI::Token::Symbol');
-   return '$self' eq $symbol->content() || '$class' eq $symbol->content();
+   return $SELF eq $symbol->content() || $CLASS eq $symbol->content();
 }
 
 1;

--- a/t/Subroutines/ProhibitManyArgs.run
+++ b/t/Subroutines/ProhibitManyArgs.run
@@ -126,6 +126,93 @@ sub foo ($+) { return 1 }
 sub foo ($$+) { return 1 }
 
 #-----------------------------------------------------------------------------
+
+## name ignore $self and $class
+## failures 0
+## parms {skip_object => 1}
+## cut
+
+sub self_foo {
+   my ($self, $bar1, $bar2, $bar3, $bar4, $bar5) = @_;
+}
+
+sub self_fu {
+   my $self = shift;
+   my $bar1 = shift;
+   my $bar2 = shift;
+   my $bar3 = shift;
+   my $bar4 = shift;
+   my $bar5 = shift;
+}
+
+sub self_bar {
+    my $self = shift;
+    my ($bar1, $bar2, $bar3, $bar4, $bar5) = @_;
+}
+
+sub class_foo {
+   my ($class, $bar1, $bar2, $bar3, $bar4, $bar5) = @_;
+}
+
+sub class_fu {
+   my $class = shift;
+   my $bar1 = shift;
+   my $bar2 = shift;
+   my $bar3 = shift;
+   my $bar4 = shift;
+   my $bar5 = shift;
+}
+
+sub class_bar {
+    my $class = shift;
+    my ($bar1, $bar2, $bar3, $bar4, $bar5) = @_;
+}
+
+#-----------------------------------------------------------------------------
+
+## name ignore $self and $class with configured max_arguments
+## failures 0
+## parms {skip_object => 1, max_arguments => 2}
+## cut
+
+sub self_foo {
+   my ($self, $bar1, $bar2) = @_;
+}
+
+sub class_foo {
+   my ($class, $bar1, $bar2) = @_;
+}
+
+#-----------------------------------------------------------------------------
+
+## name too many arguments despite ignoring $self and $class
+## failures 5
+## parms {skip_object => 1, max_arguments => 2}
+## cut
+
+sub self_foo {
+   my ($self, $bar1, $bar2, $bar3) = @_;
+}
+
+sub self_fu {
+   my $self = shift;
+   my ($bar1, $bar2, $bar3) = @_;
+}
+
+sub class_foo {
+   my ($class, $bar1, $bar2, $bar3) = @_;
+}
+
+sub class_fu {
+   my $class = shift;
+   my ($bar1, $bar2, $bar3) = @_;
+}
+
+sub classy_self {
+    my ($self, $class, $class, $self) = @_;
+}
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
This patch implements skipping of $class and $self in methods (off by default) for Subroutine::ProhibitManyArgs. It was a TODO in this policy. Please let me know if any corrections are needed.