### PR TITLE
Fix small typo in manpage of Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval

### DIFF
--- a/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
+++ b/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
@@ -366,7 +366,7 @@ true value and to test that value:
     # Constructors are no problem.
     my $object = eval { Class->new() };
 
-    # To cover the possiblity that an operation may correctly return a
+    # To cover the possibility that an operation may correctly return a
     # false value, end the block with "1":
     if ( eval { something(); 1 } ) {
         ...


### PR DESCRIPTION

Hi,

In Debian we are currently applying the following patch to
Perl-Critic.
We thought you might be interested in it too.

    Description: Fix small typo in manpage of Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval
    Origin: vendor
    Author: Salvatore Bonaccorso <carnil@debian.org>
    Last-Update: 2018-07-27
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libperl-critic-perl/raw/master/debian/patches/spelling-error-in-manpage.patch

Thanks for considering,
  Salvatore Bonaccorso,
  Debian Perl Group
