### PR TITLE
Support "::" in warning categories

### DIFF
--- a/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoWarnings.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoWarnings.pm
@@ -51,7 +51,7 @@ sub _parse_allow {
 
     if( defined $config_string ) {
         my $allowed = lc $config_string; #String of words
-        my %allowed = hashify( $allowed =~ m/ (\w+) /gxms );
+        my %allowed = hashify( $allowed =~ m/ (\w+(?:::\w+)?) /gxms );
 
         $self->{_allow} = \%allowed;
     }


### PR DESCRIPTION
`TestingAndDebugging::ProhibitNoWarnings` policy not supports warning categories with `::`, e.g. `experimental::postderef`.
