### PR TITLE
Improve.ci+fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,31 +1,173 @@
-# .appveyor.yml
+# .appveyor.yml (for Perl distributions)
 
-# * note: AppVeyor setup
-# 1. add an AppVeyor project observing the repository
-# 2. set "General / Custom configuration .yml file name" = ".appveyor.yml" within the project SETTINGS
-# 3. enable "General / Skip branches without appveyor.yml" within the project SETTINGS
+# * (APIv1) for usage instructions, see <https://github.com/rivy/CI.AppVeyor.helpers-perl/blob/stable.APIv1/README.mkd>
 
-skip_tags: true
+# ref: <https://www.appveyor.com/docs/appveyor-yml>[`@`](https://archive.is/OUJHS)
+# * "appveyor.yml" validation tool @ <https://ci.appveyor.com/tools/validate-yaml>
+
+version: "{build} ~ {branch}"
+
+branches:
+  except:
+    - gh-pages
+
+skip_tags: true     ## do not build on tags
+
+matrix:
+  allow_failures:
+    - AUTHOR_TESTING: 1
+    - TEST_SIGNATURE: 1
+    - CI_HELPER_BRANCH: canary
+    - Perl_VERSION: "5.8.8" ## allow perl v5.8.8 failures; (v5.8.8 is problematic for many projects)
+
+environment:
+  matrix:
+    - Perl_VERSION: "latest"
+      COVERAGE: "Codecov Coveralls" ## note: case sensitive!
+      AUTHOR_TESTING: 1
+      RELEASE_TESTING: 1
+    - Perl_VERSION: "5.28"
+    - Perl_VERSION: "5.26"
+    - Perl_VERSION: "5.24"
+    - Perl_VERSION: "5.22"
+    - Perl_VERSION: "5.20"
+    - Perl_VERSION: "5.16"
+    - Perl_VERSION: "5.14"
+    - Perl_VERSION: "5.12"
+    - Perl_VERSION: "5.10"
+    - Perl_VERSION: "5.8.9"
+    - Perl_VERSION: "5.8.8"
+    - Perl_VERSION: "latest"
+      CI_HELPER_BRANCH: "canary"
+      TEST_SIGNATURE: 1
+  global:
+    AUTOMATED_TESTING: 1
+    CI_CACHE_DIR: "C:\\cache"
+    #
+    # debug?
+    # CI_DEBUG: 1               ##  [ "" == false, <non-empty> == true ]; "true" enables detailed output for the helper scripts
+    #
+    ## configuration (CI/network-side settings and then ".appveyor_init.{BAT,PS1}" [if present], may override these values [by design])
+    ## ---
+    # * standard perl distribution test configuration signals
+    AUTHOR_TESTING: ""
+    RELEASE_TESTING: ""
+    # * .appveyor.yml configuration variables
+    CI_HELPER_API_VERSION: "1"  ## * API version (the expected/requested helper API version)
+    CI_HELPER_BRANCH: ""        ## "" => auto-set, valid alternates are [ "stable" (the default), "canary", BRANCH, or TAG ]
+    CI_HELPER_REPO: ""          ## "" => auto-set; allows easier use of alternate helper scripts (ie, alternate forks)
+    DEVEL_COVER_OPTIONS: ""     ## "" => auto-set, value determined by DIST_TOOLING; quoted whitespace (eg, " ") is an empty/neutral setting which also blocks auto-set
+    DIST_EXTRA_DEPS: ""         ## additional required/requested dependencies for build and/or testing
+    DIST_SUPPRESS_DEPS: ""      ## [ "" == false, <non-empty> == true ]; "true" can be useful for CORE modules, suppressing discovery and installation of dependencies, unless otherwise required (by COVERAGE or DIST_EXTRA_DEPS)
+    DIST_TOOLING: ""            ## [ "build", "make" ]; "" => auto-set based on existence of "Build.PL" and/or "Makefile.PL"
+    TEST_METHOD: ""             ## "" => auto-set based on DIST_TOOLING (`perl Build test`, `%make% test`, or `prove -bl`)
+    TEST_FILES: ""              ## "" => auto-set to "" for build/make distributions, otherwise "t" or "t xt" depending on AUTHOR_TESTING and/or RELEASE_TESTING and directory existence
+    ## ---
 
 cache:
-  - C:\strawberry -> .appveyor.yml
+# note: unused, because, unfortunately, the available cache is too small to be helpful (unshared; 1GB across all projects)
+#   - '%CI_CACHE_DIR% -> .appveyor.yml'
 
 install:
-  - if not exist "C:\strawberry" cinst strawberryperl -y
-  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - ps: ; write-host $("[{0:HH:mm:ss}].install" -f $($mark = get-date; $mark)) -f darkgray
+  # ensure CWD is project main directory
   - cd "%APPVEYOR_BUILD_FOLDER%"
-  - cpanm --installdeps .
+  # perform any special preparation (optional; distribution specific)
+  # * note: optional external file(s), global scope => allows ".appveyor.yml" to remain more stable and similar [or the same] between different distributions [eg, for automated distribution of ".appveyor.yml" changes]
+  - if EXIST ".appveyor_init.BAT" ( call .appveyor_init.BAT )
+  - ps: if ( test-path ".appveyor_init.PS1" ) { . ".\.appveyor_init.PS1" }
+  # save current-point-in-time environment (for later logging of environment variable overrides)
+  - ps: $baseline_env = @(get-childitem env:)
+  # create a working area
+  - ps: if ( ! $env:CI_TEMP_DIR ) { $env:CI_TEMP_DIR = "${env:TEMP}\${env:APPVEYOR_JOB_ID}" ; mkdir -force $env:CI_TEMP_DIR | out-null }
+  # create cache area, if missing
+  - if NOT DEFINED CI_CACHE_DIR ( set "CI_CACHE_DIR=%CI_TEMP_DIR%\cache" )
+  - if NOT EXIST "%CI_CACHE_DIR%" ( mkdir "%CI_CACHE_DIR%" )
+  # finalize HELPER repository location
+  - if NOT DEFINED CI_HELPER_API_VERSION ( set "CI_HELPER_API_VERSION=1" )
+  - if NOT DEFINED CI_HELPER_REPO ( set "CI_HELPER_REPO=https://github.com/rivy/CI.AppVeyor.helpers-perl.git" )
+  - if NOT DEFINED CI_HELPER_BRANCH ( set "CI_HELPER_BRANCH=stable" )
+  - if /i "%CI_HELPER_BRANCH%"=="canary" ( set "CI_HELPER_BRANCH=canary.APIv%CI_HELPER_API_VERSION%" )
+  - if /i "%CI_HELPER_BRANCH%"=="stable" ( set "CI_HELPER_BRANCH=stable.APIv%CI_HELPER_API_VERSION%" )
+  # find / download helpers
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (helpers)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  # * use "vendored" copy if present
+  - ps: if ( ! $env:CI_HELPERS -and (test-path ".appveyor_bin") ) { $env:CI_HELPERS=[IO.Path]::GetFullPath(".appveyor_bin") ; ${env:CI_HELPER_REPO} = ${env:APPVEYOR_REPO_NAME} ; ${env:CI_HELPER_BRANCH_DESC} = ${env:APPVEYOR_REPO_COMMIT} ; }
+  # * clone/download helpers from HELPER repo (via `git`) if needed
+  - ps: if ( ! $env:CI_HELPERS ) { $repo_path = $( mkdir "${env:CI_TEMP_DIR}\helpers" ).Fullname ; $git_cmd = "git clone ${env:CI_HELPER_REPO} `"${repo_path}`" -b ${env:CI_HELPER_BRANCH} 2>&1" ; write-host "[``${git_cmd}``]" ; & 'CMD' @( '/c', $git_cmd ) ; $err = $LASTEXITCODE ; $env:CI_HELPERS = "${repo_path}\.appveyor_bin" ; if ($err -ne 0) { exit $err } ; }
+  - ps: if ( ! $env:CI_HELPER_BRANCH_DESC ) { ${env:CI_HELPER_BRANCH_DESC} = $( pushd "${env:CI_HELPERS}" ; & 'git' @( 'describe', '--always' ) 2>&1 ; popd ) ; }
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (helpers) ... (${env:CI_HELPER_REPO}@${env:CI_HELPER_BRANCH_DESC})")
+  # resolve requested coverage with needed configuration
+  - ps: . "${env:CI_HELPERS}\#install.determine-coverage.PS1"
+  ##
+  # highlight any overrides within baseline environment
+  - ps: $baseline_env | & "${env:CI_HELPERS}\log.env-overrides.PS1"
+  ##
+  # move "C:\mingw" to avoid cross library linking (a problem with older perl versions, breaking dll compilation with "/mingw/lib/dllcrt2.o:(.text+0xd1): undefined reference to `__dyn_tls_init_callback'")
+  # * only truly needed for modules containing XS compilation, but ok for all modules
+  - move c:\mingw c:\mingw.o >NUL
+  # force branch checkout (if knowable), then reset to the specific commit ## (needed for accurate code coverage info)
+  # * this allows later apps to see the branch name using standard `git branch` operations, yet always builds the correct specific commit
+  # * ref: <https://github.com/appveyor/ci/issues/1606>[`@`](https://archive.is/RVpnF)
+  - if DEFINED APPVEYOR_REPO_BRANCH if /i "%APPVEYOR_REPO_SCM%"=="git" ( git checkout "%APPVEYOR_REPO_BRANCH%" >NUL & git reset --hard "%APPVEYOR_REPO_COMMIT%" )
+  # install perl (strawberry variant) + version verification
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (perl)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.install-perl.PS1"
+  - perl -V
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (perl) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  # determine build tooling
+  - ps: . "${env:CI_HELPERS}\#install.determine-tooling.PS1"
+  # setup DEVEL_COVER_OPTIONS, if needed
+  - ps: if (! $env:DEVEL_COVER_OPTIONS) { . "${env:CI_HELPERS}\#install.setup-cover_options.PS1" }
+  # setup testing method/options and test files
+  - ps: . "${env:CI_HELPERS}\#install.setup-testing.PS1"
+  # distribution prep prior to the build/make process (ie, build dependencies and OS_unsupported check)
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (distribution requirements and recommendations)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.setup-dist.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (distribution requirements and recommendations) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  # coverage prep
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (coverage requirements)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.setup-coverage.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (coverage requirements) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  #
+  - ps: ; write-host $("[{0:HH:mm:ss}].install ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+
+before_build:
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.before_build" -f $($mark = get-date; $mark)) -f darkgray
+  # ensure CWD is project main directory
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+  # * for non-COVERAGE builds, enable parallel processing (COVERAGE builds need sequential, correctly interleaved, output to avoid warnings)
+  - if NOT DEFINED COVERAGE (set "HARNESS_OPTIONS=j")
+  - set HARNESS_TIMER=1
+  # * for COVERAGE builds, enable coverage for `prove` testing
+  - if DEFINED COVERAGE (set HARNESS_PERL_SWITCHES=-MDevel::Cover %HARNESS_PERL_SWITCHES%)
+  # * for COVERAGE builds, preload JSON:PP to avoid JSON::PP::Boolean redefine warning (see <https://github.com/rurban/Cpanel-JSON-XS/issues/65#issuecomment-219352754>)
+  - if DEFINED COVERAGE (set HARNESS_PERL_SWITCHES=-MJSON::PP %HARNESS_PERL_SWITCHES%)
+  #
+  - ps: . "${env:CI_HELPERS}\#build-before_build.PS1"
+  # show final build-related environment variables
+  - ps: . "${env:CI_HELPERS}\log.env.PS1"
+  #
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.before_build ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
 
 build_script:
-  - perl Build.PL
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.build_script" -f $($mark = get-date; $mark)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#build-build_script.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.build_script ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
 
 test_script:
-  - Build test
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.test_script" -f $($mark = get-date; $mark)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#test-test_script.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.test_script ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
 
-# notifications:
-# To get Github PR notifications from AppVeyor, get an auth token from Github,
-# encrypt it at https://ci.appveyor.com/tools/encrypt and put it into the
-# secure field
-#  - provider: GitHubPullRequest
-#    auth_token:
-#      secure: ...
+after_test:
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.after_test" -f $($mark = get-date; $mark)) -f darkgray
+  # reporting
+  # * report any code coverage information
+  - ps: if (-not $env:OS_unsupported -and $env:COVERAGE) { $env:COVERAGE.split() | foreach { & 'CMD' @( '/c', "cover -report $_ 2>&1" ) } }
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.after_test ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+  # end with any informational or warning messages, if needed
+  - ps: if ($env:CI_SKIP) { write-host -f magenta "info:` CI_SKIP enabled" ; Add-AppveyorMessage -Message "CI_SKIP enabled" -Category Info }
+  - ps: if ($env:CI_SKIP_TEST) { write-host -f magenta "info:` CI_SKIP_TEST enabled" ; Add-AppveyorMessage -Message "CI_SKIP_TEST enabled" -Category Info }
+  # * prominent "unsupported" warning
+  - ps: if ($env:OS_unsupported) { write-host -f magenta "WARN:` OS unsupported" ; Add-AppveyorMessage -Message "OS unsupported" -Category Warning }

--- a/Build.PL
+++ b/Build.PL
@@ -37,7 +37,7 @@ my $builder = Perl::Critic::Module::Build->new(
     # Don't require a developer version of Module::Build, even if the
     # distribution tarball was created with one.  (Oops.)
     configure_requires  => {
-        'Module::Build' => '0.4024',
+        'Module::Build' => '0.4204',
     },
 
     PL_files            => get_PL_files(),

--- a/Build.PL
+++ b/Build.PL
@@ -3,7 +3,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Module::Build 0.4200;
+use Module::Build;
 # meta_merge->resources->license now takes an arrayref of URLs in 0.4200 (or
 # thereabouts, but I can't tell for sure from the Changes file).
 

--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -42,6 +42,7 @@ sub required_module_versions {
         'IPC::Open2'                    => 1,
         'List::MoreUtils'               => 0.19,
         'List::Util'                    => 0,
+        'Module::Build'                 => 0.4204,
         'Module::Pluggable'             => 3.1,
         'PPI'                           => '1.224',
         'PPI::Document'                 => '1.224',


### PR DESCRIPTION
I created an improved AppVeyor CI config (in the spirit of @haarg's Travis CI toolset) which I've been testing and using for a while and now I'm slowly releasing it into more public use. The supplied AppVeyor config (and related helper tools) is able to test all the way back to Perl v5.8.8.8 (the earliest Strawberry Perl available). Further information about the AppVeyor CI config is available at [rivy/CI.AppVeyor.helpers-perl](https://github.com/rivy/CI.AppVeyor.helpers-perl/blob/master/README.mkd).

By expanding testing, I uncovered some bugs in the Module::Build requirements. I've included the fixes in three small annotated commits.

So, this PR compiles successfully all the way back to Perl v5.8.8.8 for MSWin32/AppVeyor and Perl v5.8 for Travis (see reports at [AppVeyor CI](https://ci.appveyor.com/project/rivy/perl-perl-critic/builds/22438721) and [Travis CI](https://travis-ci.org/rivy/perl.Perl-Critic/builds/494595168)). It also includes support for code coverage (see reports at [CodeCov](https://codecov.io/gh/rivy/perl.Perl-Critic/tree/43bdb9080fa39ddb69060f939a8c80a614751c24) and [Coveralls](https://coveralls.io/github/rivy/perl.Perl-Critic?branch=improve.ci%2Bfixes)).

I hope this is acceptable, and let me know if you'd like any changes.
