### PR TITLE
Adapt tests to changes in PPI 1.248

### DIFF
--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -418,7 +418,7 @@ sub test_parse_arg_list {
         [
                 q/foo( { bar() }, {}, 'blah' )/
             =>  [
-                    ' { bar() }',
+                    [ '{ bar() }' ],
                     [ qw< {} > ],
                     [ q<'blah'> ],
                 ],

--- a/t/ValuesAndExpressions/ProhibitCommaSeparatedStatements.run
+++ b/t/ValuesAndExpressions/ProhibitCommaSeparatedStatements.run
@@ -254,7 +254,6 @@ return
 
 ## name RT #27654 - NKH example 3
 ## failures 0
-## TODO PPI parses this code as blocks and not hash constructors.
 ## cut
 
 $self->DoSomething


### PR DESCRIPTION
This patch removes a TODO for a now-fixed bug in PPI and adapts the test case in t/05_utils.t to the output caused by that change (adamkennedy/PPI@7fd14b0).

This solves #858.