### PR TITLE
MooseX::MethodAttributes::Role counts as use strict

### DIFF
--- a/lib/Perl/Critic/Utils/Constants.pm
+++ b/lib/Perl/Critic/Utils/Constants.pm
@@ -95,6 +95,7 @@ Readonly::Array our @STRICT_EQUIVALENT_MODULES => qw(
     MooseX::NonMoose
     MooseX::Singleton
     MooseX::Role::Parameterized
+    MooseX::MethodAttributes::Role
 
     Mouse
     Mouse::Role


### PR DESCRIPTION
Using this also imports Moose::Role, which also imports strict.

See https://metacpan.org/source/ETHER/MooseX-MethodAttributes-0.31/lib/MooseX/MethodAttributes/Role.pm#L36.