### PR TITLE
Increase String::Format requirement to avoid warning

### DIFF
--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -62,7 +62,7 @@ sub required_module_versions {
         'Pod::Usage'                    => 0,
         'Readonly'                      => 2.00,
         'Scalar::Util'                  => 0,
-        'String::Format'                => 1.13,
+        'String::Format'                => '1.18',
         'Task::Weaken'                  => 0,
         'Term::ANSIColor'               => '2.02',
         'Test::Builder'                 => 0.92,


### PR DESCRIPTION
Version 1.18 fixes this bug: https://rt.cpan.org/Public/Bug/Display.html?id=124147 which led to failures in many Perl::Critic extensions (which don't depend on String::Format themselves).