### PR TITLE
allow postfix dereferencing with ProhibitDoubleSigils Policy

### DIFF
--- a/lib/Perl/Critic/Policy/References/ProhibitDoubleSigils.pm
+++ b/lib/Perl/Critic/Policy/References/ProhibitDoubleSigils.pm
@@ -27,10 +27,12 @@ sub applies_to           { return 'PPI::Token::Cast'    }
 sub violates {
     my ( $self, $elem, undef ) = @_;
     return if $elem eq q{\\};
+    return if $elem =~ /[@ $ % * &] [*]/xms;
+    return if $elem eq q{$#*}; ## no critic (RequireInterpolationOfMetachars)
 
     my $sib = $elem->snext_sibling;
     return if !$sib;
-    if ( ! $sib->isa('PPI::Structure::Block') ) {
+    if ( ! $sib->isa('PPI::Structure::Block') && ! $sib->isa('PPI::Structure::Subscript') ) {
         return $self->violation( $DESC, $EXPL, $elem );
     }
     return; #ok!

--- a/t/References/ProhibitDoubleSigils.run
+++ b/t/References/ProhibitDoubleSigils.run
@@ -11,6 +11,15 @@ $some_ref = \@array;
 $some_ref = \$scalar;
 $some_ref = \&code;
 
+%hash   = $some_ref->%*;
+@array  = $some_ref->@*;
+$scalar = $some_ref->$*;
+$glob   = $some_ref->**;
+$sub    = $some_ref->&*;
+$arr_i  = $some_ref->$#*;
+@array  = $some_ref->@[0 .. 2];
+%hash   = $some_ref->%{qw/key1 key2/};
+
 #-----------------------------------------------------------------------------
 
 ## name Basic failures


### PR DESCRIPTION
ProhibitDoubleSigils policy now allows postfix dereferencing.

Closes #578 