### PR TITLE
Fix #324 RequireCheckingReturnValueOfEval

### DIFF
--- a/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
+++ b/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
@@ -45,6 +45,7 @@ sub violates {
     my $evaluated = $elem->snext_sibling() or return; # Nothing to eval!
     my $following = $evaluated->snext_sibling();
 
+    return if _is_returned( $elem );    # GitHub #324
     return if _is_in_right_hand_side_of_assignment($elem);
     return if _is_in_postfix_expression($elem);
     return if
@@ -287,6 +288,23 @@ sub _is_effectively_a_comma {
                 $elem->content() eq $COMMA
             ||  $elem->content() eq $FATCOMMA
         );
+}
+
+#-----------------------------------------------------------------------------
+# GitHub #324 (https://github.com/Perl-Critic/Perl-Critic/issues/324)
+{
+    Readonly::Scalar my $RETURN => 'return';
+
+    sub _is_returned {
+        my ( $elem ) = @_;
+        my $prev = $elem->sprevious_sibling();
+        return
+                $prev
+            &&
+                $prev->isa( 'PPI::Token::Word' )
+            &&
+                $RETURN eq $prev->content();
+    }
 }
 
 #-----------------------------------------------------------------------------

--- a/t/ErrorHandling/RequireCheckingReturnValueOfEval.run
+++ b/t/ErrorHandling/RequireCheckingReturnValueOfEval.run
@@ -408,6 +408,16 @@ $foo &&= eval { something };
 
 #-----------------------------------------------------------------------------
 
+## name return eval{} (https://github.com/Perl-Critic/Perl-Critic/issues/324)
+## failures 0
+## cut
+
+return eval { something };
+return eval "something";
+# TODO return ( eval { something } )
+
+#-----------------------------------------------------------------------------
+
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
This issue requests that the subject policy allow the value of an eval
to be returned.

The implementation is pretty simple, and only addresses the case where
the 'return' is the immediate previous significant sibling of the
'eval'.