### PR TITLE
Fix #843 false positive in ProhibitPunctuationVars

### DIFF
--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -51,6 +51,7 @@ sub required_module_versions {
         'PPI::Token::Quote::Single'     => '1.224',
         'PPI::Token::Whitespace'        => '1.224',
         'PPIx::Regexp'                  => '0.027', # Literal { deprecated in re
+        'PPIx::Regexp::Util'            => '0.068', # is_ppi_regexp_element()
         'PPIx::Utilities::Node'         => '1.001',
         'PPIx::Utilities::Statement'    => '1.001',
         'Perl::Tidy'                    => 0,

--- a/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
+++ b/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
@@ -45,6 +45,7 @@ sub violates {
     my $evaluated = $elem->snext_sibling() or return; # Nothing to eval!
     my $following = $evaluated->snext_sibling();
 
+    return if _is_returned( $elem );    # GitHub #324
     return if _is_in_right_hand_side_of_assignment($elem);
     return if _is_in_postfix_expression($elem);
     return if
@@ -287,6 +288,23 @@ sub _is_effectively_a_comma {
                 $elem->content() eq $COMMA
             ||  $elem->content() eq $FATCOMMA
         );
+}
+
+#-----------------------------------------------------------------------------
+# GitHub #324 (https://github.com/Perl-Critic/Perl-Critic/issues/324)
+{
+    Readonly::Scalar my $RETURN => 'return';
+
+    sub _is_returned {
+        my ( $elem ) = @_;
+        my $prev = $elem->sprevious_sibling();
+        return
+                $prev
+            &&
+                $prev->isa( 'PPI::Token::Word' )
+            &&
+                $RETURN eq $prev->content();
+    }
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/Perl/Critic/Policy/Variables/ProhibitPunctuationVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitPunctuationVars.pm
@@ -12,6 +12,11 @@ use Perl::Critic::Utils qw<
     :characters :severities :data_conversion :booleans
 >;
 
+use PPIx::Regexp;
+use PPIx::Regexp::Util qw<
+    __is_ppi_regexp_element
+>;
+
 use base 'Perl::Critic::Policy';
 
 our $VERSION = '1.130';
@@ -99,13 +104,16 @@ Readonly::Array my @IGNORE_FOR_INTERPOLATION =>
 #-----------------------------------------------------------------------------
 
 sub violates {
-    my ( $self, $elem, undef ) = @_;
+    my ( $self, $elem, $doc ) = @_;
 
     if ( $elem->isa('PPI::Token::Magic') ) {
         return _violates_magic( $self, $elem );
     }
     elsif ( $elem->isa('PPI::Token::HereDoc') ) {
         return _violates_heredoc( $self, $elem );
+    }
+    elsif ( __is_ppi_regexp_element( $elem ) ) {    # GitHub #843
+        return _violates_regexp( $self, $elem, $doc );
     }
 
     #the remaining applies_to() classes are all interpolated strings
@@ -114,7 +122,8 @@ sub violates {
 
 #-----------------------------------------------------------------------------
 
-# Helper functions for the three types of violations: code, quotes, heredoc
+# Helper functions for the four types of violations: code, quotes, heredoc,
+# regexp
 
 sub _violates_magic {
     my ( $self, $elem, undef ) = @_;
@@ -172,6 +181,38 @@ sub _violates_heredoc {
     }
 
     return;    # no violation
+}
+
+sub _violates_regexp {  # GitHub #843 (https://github.com/Perl-Critic/Perl-Critic/issues/843)
+    my ( $self, $elem, $doc ) = @_;
+
+    return if ( $self->{_string_mode} eq 'disable' );
+
+    my $pre = $doc->ppix_regexp_from_element( $elem )
+        or return;
+    $pre->failures()
+        and return;
+
+    my @raw_matches;
+    foreach my $code ( @{ $pre->find( 'PPIx::Regexp::Token::Code' ) || [] } ) {
+        my $code_doc = $code->ppi()
+            or next;
+        push @raw_matches, map { $_->symbol() } @{
+            $code_doc->find(  'PPI::Token::Magic' ) || [] };
+    }
+
+    my %matches = hashify( @raw_matches );
+    delete @matches{ keys %{ $self->{_allow} } };
+    if ( $self->{_string_mode} eq 'simple' ) {
+        delete @matches{@IGNORE_FOR_INTERPOLATION};
+    }
+
+    if ( keys %matches ) {
+        my $DESC = qq<$DESC in interpolated Regexp>;
+        return $self->_make_violation( $DESC, $EXPL, $elem, \%matches );
+    }
+
+    return;
 }
 
 #-----------------------------------------------------------------------------

--- a/lib/Perl/Critic/Policy/Variables/ProhibitPunctuationVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitPunctuationVars.pm
@@ -13,8 +13,8 @@ use Perl::Critic::Utils qw<
 >;
 
 use PPIx::Regexp;
-use PPIx::Regexp::Util qw<
-    __is_ppi_regexp_element
+use PPIx::Regexp::Util 0.068 qw<
+    is_ppi_regexp_element
 >;
 
 use base 'Perl::Critic::Policy';
@@ -112,7 +112,7 @@ sub violates {
     elsif ( $elem->isa('PPI::Token::HereDoc') ) {
         return _violates_heredoc( $self, $elem );
     }
-    elsif ( __is_ppi_regexp_element( $elem ) ) {    # GitHub #843
+    elsif ( is_ppi_regexp_element( $elem ) ) {    # GitHub #843
         return _violates_regexp( $self, $elem, $doc );
     }
 

--- a/t/ErrorHandling/RequireCheckingReturnValueOfEval.run
+++ b/t/ErrorHandling/RequireCheckingReturnValueOfEval.run
@@ -408,6 +408,16 @@ $foo &&= eval { something };
 
 #-----------------------------------------------------------------------------
 
+## name return eval{} (https://github.com/Perl-Critic/Perl-Critic/issues/324)
+## failures 0
+## cut
+
+return eval { something };
+return eval "something";
+# TODO return ( eval { something } )
+
+#-----------------------------------------------------------------------------
+
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4

--- a/t/Variables/ProhibitPunctuationVars.run
+++ b/t/Variables/ProhibitPunctuationVars.run
@@ -128,6 +128,7 @@ print qr<$+>;
 ## cut
 
 print qr<\$+>;
+print qr/TEST$/xsm; # GitHub #843
 
 ## name PPI::Token::QuoteLike::Readline: violations
 ## failures 1


### PR DESCRIPTION
Fix #843: Delegated interpretation of regexen to PPIx::Regexp, which is already a prerequisite.

There are failures in t/05_utils.t and xt/40_criticize-code.t, but they were present before I started working on this.
