### PR TITLE
Add pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
   description: Run the perlcritic static analyzer on Perl source files
   minimum_pre_commit_version: 2.1.0
   entry: perlcritic
-  args: [--quiet]
+  args: [--quiet, --verbose, "5"]
   language: perl
   types: [perl]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: perlcritic
+  name: perlcritic
+  description: Run the perlcritic static analyzer on Perl source files
+  minimum_pre_commit_version: 2.1.0
+  entry: perlcritic
+  args: [--quiet]
+  language: perl
+  types: [perl]


### PR DESCRIPTION
pre-commit 2.1.0 was just released with support for installing perl hooks: https://pre-commit.com/#perl

This adds configuration people can use to easily add perlcritic in their pre-commit configs. There are other pre-commit configs for perlcritic around, but this uses the native installation capability meaning people don't have to bother installing perlcritic, it will get pulled in automatically, and respect the revision specified in the config.

To test, install pre-commit, create this config to the top level of a git repository somewhere containing perl files as .pre-commit-config.yaml (no need to add or commit it, just create the file), and run pre-commit run perlcritic --all-files.

```yaml
repos:
  - repo: https://github.com/scop/Perl-Critic
    rev: eea3d54170e3646c72efc59a5bfc0aaa7d68bfdd
    hooks:
      - id: perlcritic
```

Later, if/when this is part of perlcritic proper, the config will be similar, just with the official repo URL and revision, or more usually a release tag, as appropriate like the user wants.