### PR TITLE
ProhibitStringyEval: allow package declaration when allow_includes = true

### DIFF
--- a/t/BuiltinFunctions/ProhibitStringyEval.run
+++ b/t/BuiltinFunctions/ProhibitStringyEval.run
@@ -29,7 +29,7 @@ $hash1{eval} = 1;
 #-----------------------------------------------------------------------------
 
 ## name Eval of include statement without allow_includes set
-## failures 20
+## failures 40
 ## cut
 
 eval 'use Foo';
@@ -41,6 +41,15 @@ eval 'require Foo qw< blah >';
 eval 'use Foo 1.2 qw< blah >';
 eval 'require Foo 1.2 qw< blah >';
 
+eval 'package Pkg; use Foo';
+eval 'package Pkg; require Foo';
+eval 'package Pkg; use Foo 1.2';
+eval 'package Pkg; require Foo 1.2';
+eval 'package Pkg; use Foo qw< blah >';
+eval 'package Pkg; require Foo qw< blah >';
+eval 'package Pkg; use Foo 1.2 qw< blah >';
+eval 'package Pkg; require Foo 1.2 qw< blah >';
+
 eval 'use Foo; 1;';
 eval 'require Foo; 1;';
 eval 'use Foo 1.2; 1;';
@@ -50,10 +59,24 @@ eval 'require Foo qw< blah >; 1;';
 eval 'use Foo 1.2 qw< blah >; 1;';
 eval 'require Foo 1.2 qw< blah >; 1;';
 
+eval 'package Pkg; use Foo; 1;';
+eval 'package Pkg; require Foo; 1;';
+eval 'package Pkg; use Foo 1.2; 1;';
+eval 'package Pkg; require Foo 1.2; 1;';
+eval 'package Pkg; use Foo qw< blah >; 1;';
+eval 'package Pkg; require Foo qw< blah >; 1;';
+eval 'package Pkg; use Foo 1.2 qw< blah >; 1;';
+eval 'package Pkg; require Foo 1.2 qw< blah >; 1;';
+
 eval "use $thingy;";
 eval "require $thingy;";
 eval "use $thingy; 1;";
 eval "require $thingy; 1;";
+
+eval "package $pkg; use $thingy;";
+eval "package $pkg; require $thingy;";
+eval "package $pkg; use $thingy; 1;";
+eval "package $pkg; require $thingy; 1;";
 
 #-----------------------------------------------------------------------------
 
@@ -71,6 +94,15 @@ eval 'require Foo qw< blah >';
 eval 'use Foo 1.2 qw< blah >';
 eval 'require Foo 1.2 qw< blah >';
 
+eval 'package Pkg; use Foo';
+eval 'package Pkg; require Foo';
+eval 'package Pkg; use Foo 1.2';
+eval 'package Pkg; require Foo 1.2';
+eval 'package Pkg; use Foo qw< blah >';
+eval 'package Pkg; require Foo qw< blah >';
+eval 'package Pkg; use Foo 1.2 qw< blah >';
+eval 'package Pkg; require Foo 1.2 qw< blah >';
+
 eval 'use Foo; 1;';
 eval 'require Foo; 1;';
 eval 'use Foo 1.2; 1;';
@@ -80,21 +112,39 @@ eval 'require Foo qw< blah >; 1;';
 eval 'use Foo 1.2 qw< blah >; 1;';
 eval 'require Foo 1.2 qw< blah >; 1;';
 
+eval 'package Pkg; use Foo; 1;';
+eval 'package Pkg; require Foo; 1;';
+eval 'package Pkg; use Foo 1.2; 1;';
+eval 'package Pkg; require Foo 1.2; 1;';
+eval 'package Pkg; use Foo qw< blah >; 1;';
+eval 'package Pkg; require Foo qw< blah >; 1;';
+eval 'package Pkg; use Foo 1.2 qw< blah >; 1;';
+eval 'package Pkg; require Foo 1.2 qw< blah >; 1;';
+
 eval "use $thingy;";
 eval "require $thingy;";
 eval "use $thingy; 1;";
 eval "require $thingy; 1;";
 
+eval "package $pkg; use $thingy;";
+eval "package $pkg; require $thingy;";
+eval "package $pkg; use $thingy; 1;";
+eval "package $pkg; require $thingy; 1;";
+
 #-----------------------------------------------------------------------------
 
 ## name Eval of include statement with allow_includes set but extra stuff afterwards
-## failures 3
+## failures 6
 ## parms { allow_includes => 1 }
 ## cut
 
 eval 'use Foo; blah;';
 eval 'require Foo; 2; 1;';
 eval 'use $thingy;';
+
+eval 'package Pkg; use Foo; blah;';
+eval 'package Pkg; require Foo; 2; 1;';
+eval 'package Pkg; use $thingy;';
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
The ProhibitStringyEval policy can be relaxed to allow `eval` strings that only import a library file, but this doesn't allow `eval` strings that export a library file into another package's namespace, i.e.:

```perl
eval "package $pkg; use $module; 1;"
```

This appears to be a common idiom among modules that load code in their caller's namespace; the [Import::Into documentation](https://metacpan.org/pod/Import::Into) specifically identifies it as a technique that is guaranteed to work regardless of how `$module` exports its symbols. It isn't possible to do this using the block form of `eval` (as recommended by ProhibitStringyEval), because the NAMESPACE given to `package` must be a bareword.

This PR extends the permissiveness granted by `allow_includes` to also allow a leading `package` statement in `eval` strings.

Minutiae:

* The logic of checking for an optional leading `package` statement and an optional trailing number adds quite a bit of complexity to the `_string_eval_is_an_include` sub, so I've tried to simplify it: first it checks that the order of the statements in the `eval` string is permissible, then it checks that the structure of each statement is permissible.
* `$accept_package` doesn't do any validation of the NAMESPACE parameter. Since it has to be a bareword by the time the string is evaluated, I don't believe this is a problem.