### PR TITLE
Consider using List::SomeUtils in place of List::MoreUtils.

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ Perl::Critic requires the following modules:
 
 [IO::String](https://metacpan.org/pod/IO::String)
 
-[List::MoreUtils](https://metacpan.org/pod/List::MoreUtils)
+[List::SomeUtils](https://metacpan.org/pod/List::SomeUtils)
 
 [List::Util](https://metacpan.org/pod/List::Util)
 

--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -40,7 +40,7 @@ sub required_module_versions {
         'Getopt::Long'                  => 0,
         'IO::String'                    => 0,
         'IPC::Open2'                    => 1,
-        'List::MoreUtils'               => 0.19,
+        'List::SomeUtils'               => 0.19,
         'List::Util'                    => 0,
         'Module::Build'                 => 0.4204,
         'Module::Pluggable'             => 3.1,

--- a/lib/Perl/Critic.pm
+++ b/lib/Perl/Critic.pm
@@ -10,7 +10,7 @@ use Readonly;
 use Exporter 'import';
 
 use File::Spec;
-use List::MoreUtils qw< firstidx >;
+use List::SomeUtils qw< firstidx >;
 use Scalar::Util qw< blessed >;
 
 use Perl::Critic::Exception::Configuration::Generic;
@@ -848,7 +848,7 @@ L<File::Which>
 
 L<IO::String>
 
-L<List::MoreUtils>
+L<List::SomeUtils>
 
 L<List::Util>
 

--- a/lib/Perl/Critic/Config.pm
+++ b/lib/Perl/Critic/Config.pm
@@ -7,7 +7,7 @@ use warnings;
 use English qw(-no_match_vars);
 use Readonly;
 
-use List::MoreUtils qw(any none apply);
+use List::SomeUtils qw(any none apply);
 use Scalar::Util qw(blessed);
 
 use Perl::Critic::Exception::AggregateConfiguration;

--- a/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitBooleanGrep.pm
+++ b/lib/Perl/Critic/Policy/BuiltinFunctions/ProhibitBooleanGrep.pm
@@ -88,7 +88,7 @@ __END__
 
 =head1 NAME
 
-Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep - Use C<List::MoreUtils::any> instead of C<grep> in boolean context.
+Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep - Use C<List::SomeUtils::any> or C<List::MoreUtils::any> instead of C<grep> in boolean context.
 
 
 =head1 AFFILIATION
@@ -108,8 +108,9 @@ match.
 But consider the case of a long array where the first element is a
 match.  Boolean C<grep> still checks all of the rest of the elements
 needlessly.  Instead, a better solution is to use the C<any> function
-from L<List::MoreUtils|List::MoreUtils>, which short-circuits after
-the first successful match to save time.
+from either L<List::SomeUtils|List::SomeUtils> or
+L<List::MoreUtils|List::MoreUtils>, which short-circuits after the
+first successful match to save time.
 
 
 =head1 CONFIGURATION

--- a/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
+++ b/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw( none any );
+use List::SomeUtils qw( none any );
 
 use Perl::Critic::Utils qw{
     :booleans :characters :severities :data_conversion :classification :ppi

--- a/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
+++ b/lib/Perl/Critic/Policy/ControlStructures/ProhibitMutatingListFunctions.pm
@@ -24,7 +24,7 @@ Readonly::Array my @CPAN_LIST_FUNCS    => _get_cpan_list_funcs();
 
 sub _get_cpan_list_funcs {
     return  qw( List::Util::first ),
-        map { 'List::MoreUtils::'.$_ } _get_list_moreutils_funcs();
+        map { ('List::MoreUtils::'.$_, 'List::SomeUtils::'.$_) } _get_list_moreutils_funcs();
 }
 
 #-----------------------------------------------------------------------------
@@ -274,7 +274,7 @@ source array.  This IS technically allowed, but those side effects can
 be quite surprising, especially when the array being passed is C<@_>
 or perhaps C<values(%ENV)>!  Instead authors should restrict in-place
 array modification to C<for(@array) { ... }> constructs instead, or
-use C<List::MoreUtils::apply()>.
+use C<List::SomeUtiles:apply()> or C<List::MoreUtils::apply()>.
 
 =head1 CONFIGURATION
 
@@ -283,6 +283,9 @@ By default, this policy applies to the following list functions:
     map grep
     List::Util qw(first)
     List::MoreUtils qw(any all none notall true false firstidx
+                       first_index lastidx last_index insert_after
+                       insert_after_string)
+    List::SomeUtils qw(any all none notall true false firstidx
                        first_index lastidx last_index insert_after
                        insert_after_string)
 
@@ -299,16 +302,20 @@ Or, one can just append to the list like so:
 =head1 LIMITATIONS
 
 This policy deliberately does not apply to C<for (@array) { ... }> or
-C<List::MoreUtils::apply()>.
+C<List::MoreUtils::apply()> C<List::SomeUtils::apply()>.
 
 Currently, the policy only detects explicit external module usage like
 this:
 
     my @out = List::MoreUtils::any {s/^foo//} @in;
+    my @out = List::SomeUtils::any {s/^foo//} @in;
 
 and not like this:
 
     use List::MoreUtils qw(any);
+    my @out = any {s/^foo//} @in;
+
+    use List::SomeUtils qw(any);
     my @out = any {s/^foo//} @in;
 
 This policy looks only for modifications of C<$_>.  Other naughtiness

--- a/lib/Perl/Critic/Policy/Documentation/PodSpelling.pm
+++ b/lib/Perl/Critic/Policy/Documentation/PodSpelling.pm
@@ -10,7 +10,7 @@ use Readonly;
 use File::Spec;
 use File::Temp;
 use IO::String qw< >;
-use List::MoreUtils qw(uniq);
+use List::SomeUtils qw(uniq);
 use Pod::Spell qw< >;
 use Text::ParseWords qw< >;
 

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitJoinedReadline.pm
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 use Readonly;
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Utils qw{ :severities :classification parse_arg_list };
 use base 'Perl::Critic::Policy';

--- a/lib/Perl/Critic/Policy/InputOutput/RequireBriefOpen.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/RequireBriefOpen.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Readonly;
 
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Utils qw{ :severities :classification :booleans
     hashify parse_arg_list

--- a/lib/Perl/Critic/Policy/Miscellanea/ProhibitUselessNoCritic.pm
+++ b/lib/Perl/Critic/Policy/Miscellanea/ProhibitUselessNoCritic.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Readonly;
 
-use List::MoreUtils qw< none >;
+use List::SomeUtils qw< none >;
 
 use Perl::Critic::Utils qw{ :severities :classification hashify };
 use base 'Perl::Critic::Policy';

--- a/lib/Perl/Critic/Policy/Modules/ProhibitAutomaticExportation.pm
+++ b/lib/Perl/Critic/Policy/Modules/ProhibitAutomaticExportation.pm
@@ -6,7 +6,7 @@ use warnings;
 use Readonly;
 
 use Perl::Critic::Utils qw{ :severities };
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 use base 'Perl::Critic::Policy';
 
 our $VERSION = '1.138';

--- a/lib/Perl/Critic/Policy/Modules/RequireVersionVar.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireVersionVar.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Utils qw{ :severities };
 use base 'Perl::Critic::Policy';

--- a/lib/Perl/Critic/Policy/NamingConventions/Capitalization.pm
+++ b/lib/Perl/Critic/Policy/NamingConventions/Capitalization.pm
@@ -7,7 +7,7 @@ use warnings;
 use English qw< -no_match_vars >;
 use Readonly;
 
-use List::MoreUtils qw< any >;
+use List::SomeUtils qw< any >;
 
 use Perl::Critic::Exception::AggregateConfiguration;
 use Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue;

--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitEnumeratedClasses.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitEnumeratedClasses.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use English qw(-no_match_vars);
-use List::MoreUtils qw(all);
+use List::SomeUtils qw(all);
 use Readonly;
 
 use Perl::Critic::Utils qw{ :booleans :severities hashify };

--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitSingleCharAlternation.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitSingleCharAlternation.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Carp;
 use English qw(-no_match_vars);
-use List::MoreUtils qw(all);
+use List::SomeUtils qw(all);
 use Readonly;
 
 use Perl::Critic::Utils qw{ :booleans :characters :severities };

--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Carp;
 use English qw(-no_match_vars);
-use List::MoreUtils qw(none);
+use List::SomeUtils qw(none);
 use Readonly;
 use Scalar::Util qw(refaddr);
 

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitUnusedPrivateSubroutines.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 use English qw< $EVAL_ERROR -no_match_vars >;
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 use Readonly;
 
 use Perl::Critic::Utils qw{

--- a/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoStrict.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoStrict.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw(all);
+use List::SomeUtils qw(all);
 
 use Perl::Critic::Utils qw{ :characters :severities :data_conversion };
 use base 'Perl::Critic::Policy';

--- a/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoWarnings.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/ProhibitNoWarnings.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw(all);
+use List::SomeUtils qw(all);
 
 use Perl::Critic::Exception::Fatal::Internal qw{ throw_internal };
 use Perl::Critic::Utils qw{ :characters :severities :data_conversion };

--- a/lib/Perl/Critic/Policy/TestingAndDebugging/RequireTestLabels.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/RequireTestLabels.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 use Perl::Critic::Utils qw{
     :characters :severities :data_conversion :classification :ppi
 };

--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitInterpolationOfLiterals.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/ProhibitInterpolationOfLiterals.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Readonly;
 
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Utils qw{ :characters :severities :data_conversion };
 use base 'Perl::Critic::Policy';

--- a/lib/Perl/Critic/Policy/Variables/ProhibitAugmentedAssignmentInDeclaration.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitAugmentedAssignmentInDeclaration.pm
@@ -3,7 +3,7 @@ package Perl::Critic::Policy::Variables::ProhibitAugmentedAssignmentInDeclaratio
 use 5.006001;
 use strict;
 use warnings;
-use List::MoreUtils qw{ firstval };
+use List::SomeUtils qw{ firstval };
 use Readonly;
 
 use Perl::Critic::Utils qw{ :severities :data_conversion };

--- a/lib/Perl/Critic/Policy/Variables/ProhibitPackageVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitPackageVars.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Readonly;
 
-use List::MoreUtils qw(all);
+use List::SomeUtils qw(all);
 
 use Perl::Critic::Utils qw{
     :booleans :characters :severities :data_conversion

--- a/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitReusedNames.pm
@@ -3,7 +3,7 @@ package Perl::Critic::Policy::Variables::ProhibitReusedNames;
 use 5.006001;
 use strict;
 use warnings;
-use List::MoreUtils qw(part);
+use List::SomeUtils qw(part);
 use Readonly;
 
 use Perl::Critic::Utils qw{ :severities :classification :data_conversion };

--- a/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitUnusedVariables.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Readonly;
-use List::MoreUtils qw< any >;
+use List::SomeUtils qw< any >;
 
 use PPI::Token::Symbol;
 use PPIx::QuoteLike;

--- a/lib/Perl/Critic/PolicyFactory.pm
+++ b/lib/Perl/Critic/PolicyFactory.pm
@@ -7,7 +7,7 @@ use warnings;
 use English qw(-no_match_vars);
 
 use File::Spec::Unix qw();
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Utils qw{
     :characters

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -15,7 +15,7 @@ use File::Spec qw();
 use Scalar::Util qw( blessed );
 use B::Keywords qw();
 use PPI::Token::Quote::Single;
-use List::MoreUtils qw(any);
+use List::SomeUtils qw(any);
 
 use Perl::Critic::Exception::Fatal::Generic qw{ throw_generic };
 use Perl::Critic::Utils::PPI qw< is_ppi_expression_or_generic_statement >;

--- a/lib/Test/Perl/Critic/Policy.pm
+++ b/lib/Test/Perl/Critic/Policy.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Carp qw< croak confess >;
 use English qw< -no_match_vars >;
-use List::MoreUtils qw< all none >;
+use List::SomeUtils qw< all none >;
 use Readonly;
 
 use Test::Builder qw<>;

--- a/t/01_config.t
+++ b/t/01_config.t
@@ -7,7 +7,7 @@ use warnings;
 use English qw< -no_match_vars >;
 
 use File::Spec;
-use List::MoreUtils qw(all any);
+use List::SomeUtils qw(all any);
 
 use Perl::Critic::Exception::AggregateConfiguration;
 use Perl::Critic::Config qw<>;

--- a/t/09_theme.t
+++ b/t/09_theme.t
@@ -6,7 +6,7 @@ use warnings;
 
 use English qw(-no_match_vars);
 
-use List::MoreUtils qw(any all none);
+use List::SomeUtils qw(any all none);
 
 use Perl::Critic::TestUtils;
 use Perl::Critic::PolicyFactory;

--- a/t/Variables/RequireLocalizedPunctuationVars.run.PL
+++ b/t/Variables/RequireLocalizedPunctuationVars.run.PL
@@ -8,7 +8,7 @@ use English qw(-no_match_vars);
 use Carp qw(confess);
 
 use B::Keywords qw();
-use List::MoreUtils qw< apply uniq >;
+use List::SomeUtils qw< apply uniq >;
 
 my $this_program = __FILE__;
 (my $test_file_name = $this_program) =~ s< [.] PL \z ><>xms;


### PR DESCRIPTION
The former is in my experience has a less complicated install and is more reliable.

The first commit updates the documentation of two policies to at least mention `List::SomeUtils` in the same context as `List::MoreUtils`.  It also updates a policy that critiques the same functions from `List::SomeUtils`.  Since SomeUtils is a drop in replacement this seems reasonable.