### PR TITLE
Resolve #912. Add Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -88,6 +88,7 @@ lib/Perl/Critic/Policy/Documentation/RequirePodSections.pm
 lib/Perl/Critic/Policy/ErrorHandling/RequireCarping.pm
 lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
 lib/Perl/Critic/Policy/InputOutput/ProhibitBacktickOperators.pm
+lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordDirHandles.pm
 lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordFileHandles.pm
 lib/Perl/Critic/Policy/InputOutput/ProhibitExplicitStdin.pm
 lib/Perl/Critic/Policy/InputOutput/ProhibitInteractiveTest.pm
@@ -306,6 +307,7 @@ t/ErrorHandling/RequireCarping.run
 t/ErrorHandling/RequireCheckingReturnValueOfEval.run
 t/gh-734.t
 t/InputOutput/ProhibitBacktickOperators.run
+t/InputOutput/ProhibitBarewordDirHandles.run
 t/InputOutput/ProhibitBarewordFileHandles.run
 t/InputOutput/ProhibitExplicitStdin.run
 t/InputOutput/ProhibitInteractiveTest.run

--- a/examples/perlcriticrc
+++ b/examples/perlcriticrc
@@ -196,6 +196,7 @@ severity   = 4
 [ValuesAndExpressions::ProhibitInterpolationOfLiterals]
 [ValuesAndExpressions::ProhibitLeadingZeros]
 [InputOutput::ProhibitBarewordFileHandles]
+[InputOutput::ProhibitBarewordDirHandles]
 [Miscellanea::ProhibitTies]
 
 

--- a/examples/perlcriticrc-conway
+++ b/examples/perlcriticrc-conway
@@ -109,6 +109,9 @@ severity   = 3
 [Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles]
 severity   = 5
 
+[Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles]
+severity   = 5
+
 [Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest]
 severity   = 4
 

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordDirHandles.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordDirHandles.pm
@@ -47,7 +47,7 @@ sub violates {
     if ( $token->isa('PPI::Token::Symbol') ) {
         return $self->violation($DESC, $EXPL, $elem) if $token =~ m/^[*]/xms;
     } elsif ( $token->isa('PPI::Token::Word') ) {
-        return $self->violation($DESC, $EXPL, $elem) unless $token =~ m/^(?:my|our)$/xms;
+        return $self->violation($DESC, $EXPL, $elem) if $token !~ m/^(?:my|our)$/xms;
     }
 
     return; #ok!
@@ -78,7 +78,7 @@ because they are global, and you have no idea if that symbol already
 points to some other file or directory handle.  You can mitigate some of that risk
 by C<local>izing the symbol first, but that's pretty ugly.  Since Perl
 5.6, you can use an undefined scalar variable as a lexical reference
-to an anonymous filehandle or dirhandle.  Alternatively, see the
+to an anonymous file handle or directory handle.  Alternatively, see the
 L<IO::Handle|IO::Handle> or L<IO::Dir|IO::Dir>
 modules for an object-oriented approach.
 

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordDirHandles.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitBarewordDirHandles.pm
@@ -1,0 +1,131 @@
+package Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles;
+
+use 5.006001;
+use strict;
+use warnings;
+use Readonly;
+
+use Perl::Critic::Utils qw{ :severities :classification :ppi };
+use base 'Perl::Critic::Policy';
+
+our $VERSION = '1.138';
+
+#-----------------------------------------------------------------------------
+
+Readonly::Scalar my $DESC => q{Bareword dir handle opened};
+Readonly::Scalar my $EXPL => [ 202, 204 ];
+
+#-----------------------------------------------------------------------------
+
+sub supported_parameters { return ()                  }
+sub default_severity     { return $SEVERITY_HIGHEST   }
+sub default_themes       { return qw( core pbp bugs certrec ) }
+sub applies_to           { return 'PPI::Token::Word'  }
+
+#-----------------------------------------------------------------------------
+
+sub violates {
+    my ($self, $elem, undef) = @_;
+
+    return if $elem->content() ne 'opendir';
+    return if ! is_function_call($elem);
+
+    my $first_arg = ( parse_arg_list($elem) )[0];
+    return if !$first_arg;
+    my $token = $first_arg->[0];
+    return if !$token;
+
+    if ( $token->isa('PPI::Token::Word') && $token eq 'local' ) {  # handle local *DH
+        $token = $first_arg->[1]; # the token that follows local in the first argument
+        return if !$token;
+    }
+    if ( $token->isa('PPI::Token::Cast') && $token eq q{\\} ) {    # handle \*DH
+        $token = $first_arg->[1]; # the token that follows \ in the first argument
+        return if !$token;
+    }
+
+    if ( $token->isa('PPI::Token::Symbol') ) {
+        return $self->violation($DESC, $EXPL, $elem) if $token =~ m/^[*]/xms;
+    } elsif ( $token->isa('PPI::Token::Word') ) {
+        return $self->violation($DESC, $EXPL, $elem) unless $token =~ m/^(?:my|our)$/xms;
+    }
+
+    return; #ok!
+}
+
+1;
+
+__END__
+
+#-----------------------------------------------------------------------------
+
+=pod
+
+=head1 NAME
+
+Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles - Write C<opendir my $dh, $dirname;> instead of C<opendir DH, $dirname;>.
+
+=head1 AFFILIATION
+
+This Policy is part of the core L<Perl::Critic|Perl::Critic>
+distribution.
+
+
+=head1 DESCRIPTION
+
+Using bareword symbols to refer to directory handles is particularly evil
+because they are global, and you have no idea if that symbol already
+points to some other file or directory handle.  You can mitigate some of that risk
+by C<local>izing the symbol first, but that's pretty ugly.  Since Perl
+5.6, you can use an undefined scalar variable as a lexical reference
+to an anonymous filehandle or dirhandle.  Alternatively, see the
+L<IO::Handle|IO::Handle> or L<IO::Dir|IO::Dir>
+modules for an object-oriented approach.
+
+    opendir DH, $some_dir;            #not ok
+    opendir *DH, $some_dir;           #not ok
+    opendir \*DH, $some_dir;          #not ok
+    opendir local *DH, $some_dir;     #not ok
+    opendir $dh, $some_dir;           #ok
+    opendir my $dh, $some_dir;        #ok
+    opendir our $dh, $some_dir;       #ok
+    opendir local $dh, $some_dir;     #ok
+    my $dh = IO::Dir->new($some_dir); #ok
+
+And Perl7 will probably drop support for bareword filehandles.
+
+=head1 CONFIGURATION
+
+This Policy is not configurable except for the standard options.
+
+
+=head1 SEE ALSO
+
+L<Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles::Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles>
+
+L<IO::Handle|IO::Handle>
+
+L<IO::Dir|IO::Dir>
+
+=head1 AUTHOR
+
+Jeffrey Ryan Thalhammer <jeff@imaginative-software.com>,
+C<github.com/pali>, C<github.com/raforg>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2005-2011, 2020 Imaginative Software Systems.  All rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :

--- a/t/InputOutput/ProhibitBarewordDirHandles.run
+++ b/t/InputOutput/ProhibitBarewordDirHandles.run
@@ -1,0 +1,101 @@
+## name basic failures
+## failures 4
+## cut
+
+opendir DH, $some_dir;
+opendir DH, $some_dir or die;
+opendir(DH, $some_dir);
+opendir(DH, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name typeglob failures
+## failures 4
+## cut
+
+opendir *DH, $some_dir;
+opendir *DH, $some_dir or die;
+opendir(*DH, $some_dir);
+opendir(*DH, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name typeglob ref failures
+## failures 4
+## cut
+
+opendir \*DH, $some_dir;
+opendir \*DH, $some_dir or die;
+opendir(\*DH, $some_dir);
+opendir(\*DH, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name local typeglob failures
+## failures 4
+## cut
+
+opendir local *DH, $some_dir;
+opendir local *DH, $some_dir or die;
+opendir(local *DH, $some_dir);
+opendir(local *DH, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name basic passes
+## failures 0
+## cut
+
+opendir $dh, $some_dir;
+opendir $dh, $some_dir or die;
+opendir($dh, $some_dir);
+opendir($dh, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name my scalar passes
+## failures 0
+## cut
+
+opendir my $dh, $some_dir;
+opendir my $dh, $some_dir or die;
+opendir(my $dh, $some_dir);
+opendir(my $dh, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name our scalar passes
+## failures 0
+## cut
+
+opendir our $dh, $some_dir;
+opendir our $dh, $some_dir or die;
+opendir(our $dh, $some_dir);
+opendir(our $dh, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+## name local scalar passes
+## failures 0
+## cut
+
+opendir local $dh, $some_dir;
+opendir local $dh, $some_dir or die;
+opendir(local $dh, $some_dir);
+opendir(local $dh, $some_dir) or die;
+
+#-----------------------------------------------------------------------------
+
+$foo{opendir}; # not a function call
+{opendir}; # zero args, for Devel::Cover
+
+#-----------------------------------------------------------------------------
+
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :


### PR DESCRIPTION
This adds a new policy Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles to check for bareword directory handles and typeglob directory handles in the way that Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles does for file handles but more thoroughly to help perl developers prepare for perl7 where support for bareword file/directory handles will probably go away.