### PR TITLE
also support I<> and B<> formattings

### DIFF
--- a/lib/Perl/Critic/Policy/Documentation/RequirePackageMatchesPodName.pm
+++ b/lib/Perl/Critic/Policy/Documentation/RequirePackageMatchesPodName.pm
@@ -58,8 +58,8 @@ sub violates {
         }
 
         # idea: worry about POD escapes?
-        $pod_pkg =~ s{\A [CL]<(.*)>\z}{$1}gxms; # unwrap
-        $pod_pkg =~ s{\'}{::}gxms;              # perl4 -> perl5
+        $pod_pkg =~ s{\A [BCIL]<(.*)>\z}{$1}gxms; # unwrap
+        $pod_pkg =~ s{\'}{::}gxms;                # perl4 -> perl5
 
         foreach my $stmt ( @{ $doc->find('PPI::Statement::Package') || [] } ) {
             my $pkg = $stmt->namespace();

--- a/t/Documentation/RequirePackageMatchesPodName.run
+++ b/t/Documentation/RequirePackageMatchesPodName.run
@@ -162,6 +162,46 @@ Blah...
 
 #-----------------------------------------------------------------------------
 
+## name A good match with B<>
+## failures 0
+## cut
+package Foo;
+
+=pod
+
+=head1 NAME
+
+B<Foo> - A module that does stuff
+
+=head1 DESCRIPTION
+
+Blah...
+
+=cut
+
+
+#-----------------------------------------------------------------------------
+
+## name A good match with I<>
+## failures 0
+## cut
+package Foo;
+
+=pod
+
+=head1 NAME
+
+I<Foo> - A module that does stuff
+
+=head1 DESCRIPTION
+
+Blah...
+
+=cut
+
+
+#-----------------------------------------------------------------------------
+
 ## name Multiple packages
 ## failures 0
 ## cut


### PR DESCRIPTION
This is a fix for #913 . As the formattings C<> and L<> are already handled, the other formattings should be supported, too.