### PR TITLE
Tidy some test imports

### DIFF
--- a/t/00_modules.t
+++ b/t/00_modules.t
@@ -6,7 +6,7 @@ use warnings;
 
 use PPI::Document;
 
-use Perl::Critic::TestUtils qw(bundled_policy_names);
+use Perl::Critic::TestUtils qw( bundled_policy_names critique );
 
 use Test::More;
 

--- a/t/00_versions.t
+++ b/t/00_versions.t
@@ -4,9 +4,9 @@ use strict;
 use warnings;
 
 use English qw< -no_match_vars >;
-use Carp qw< confess >;
+use Carp qw( confess );
 
-use File::Find;
+use File::Find qw( find );
 
 use Test::More;
 
@@ -14,7 +14,7 @@ plan 'no_plan';
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 find({wanted => \&check_version, no_chdir => 1}, 'blib');

--- a/t/01_config_bad_perlcriticrc.t
+++ b/t/01_config_bad_perlcriticrc.t
@@ -8,17 +8,17 @@ use strict;
 use warnings;
 
 use English qw< -no_match_vars >;
-use Readonly;
+use Readonly ();
 
 use Test::More;
 
 use Perl::Critic::PolicyFactory (-test => 1);
-use Perl::Critic;
-use Perl::Critic::Utils::Constants qw< $_MODULE_VERSION_TERM_ANSICOLOR >;
+use Perl::Critic ();
+use Perl::Critic::Utils::Constants qw( $_MODULE_VERSION_TERM_ANSICOLOR );
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my @color_severity_params;

--- a/t/01_policy_config.t
+++ b/t/01_policy_config.t
@@ -4,7 +4,6 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Carp qw< confess >;
 
 use Perl::Critic::PolicyConfig;
 
@@ -12,7 +11,7 @@ use Test::More tests => 28;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 

--- a/t/02_policy.t
+++ b/t/02_policy.t
@@ -10,7 +10,7 @@ use Test::More tests => 29;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 # Perl::Critic::Policy is an abstract class, so it can't be instantiated

--- a/t/03_annotations.t
+++ b/t/03_annotations.t
@@ -7,7 +7,7 @@ use warnings;
 use PPI::Document;
 
 use Perl::Critic::Annotation;
-use Perl::Critic::TestUtils qw(bundled_policy_names);
+use Perl::Critic::TestUtils qw( bundled_policy_names );
 
 use Test::More;
 

--- a/t/03_pragmas.t
+++ b/t/03_pragmas.t
@@ -7,7 +7,7 @@ use warnings;
 use Test::More (tests => 32);
 use Perl::Critic::PolicyFactory (-test => 1);
 
-use Perl::Critic::TestUtils qw(critique);
+use Perl::Critic::TestUtils qw( critique );
 
 our $VERSION = '1.140';
 

--- a/t/04_options_processor.t
+++ b/t/04_options_processor.t
@@ -14,7 +14,7 @@ use Test::More tests => 54;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 {

--- a/t/05_utils_perl.t
+++ b/t/05_utils_perl.t
@@ -10,7 +10,7 @@ use Test::More tests => 7;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------

--- a/t/05_utils_pod.t
+++ b/t/05_utils_pod.t
@@ -5,8 +5,7 @@ use strict;
 use warnings;
 
 use English qw< -no_match_vars >;
-use Readonly;
-use Carp qw< confess >;
+use Readonly ();
 
 
 use Perl::Critic::Utils::POD qw< :all >;
@@ -16,7 +15,7 @@ use Test::More tests => 61;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 Readonly::Scalar my $EXCEPTION_MESSAGE_REGEX =>

--- a/t/05_utils_ppi.t
+++ b/t/05_utils_ppi.t
@@ -27,7 +27,7 @@ use Test::More tests => 64;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my @ppi_statement_classes = qw{

--- a/t/06_violation.t
+++ b/t/06_violation.t
@@ -6,8 +6,8 @@ use warnings;
 
 use English qw< -no_match_vars >;
 
-use File::Basename qw< basename >;
-use File::Spec::Functions qw< catdir catfile >;
+use File::Basename qw( basename );
+use File::Spec::Functions qw( catdir catfile );
 use PPI::Document q< >;
 use PPI::Document::File q< >;
 
@@ -18,7 +18,7 @@ use Test::More tests => 69;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 use lib catdir( qw< t 06_violation.d lib > );

--- a/t/07_command.t
+++ b/t/07_command.t
@@ -5,18 +5,17 @@ use strict;
 use warnings;
 
 use English qw(-no_match_vars);
-use Carp qw< confess >;
+use Carp qw( confess );
 
-use File::Spec;
 
-use Perl::Critic::Command qw< run >;
+use Perl::Critic::Command ();
 use Perl::Critic::Utils qw< :characters >;
 
 use Test::More tests => 57;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 local @ARGV = ();

--- a/t/07_perlcritic.t
+++ b/t/07_perlcritic.t
@@ -4,13 +4,13 @@ use 5.006001;
 use strict;
 use warnings;
 
-use File::Spec;
+use File::Spec ();
 
 use Test::More tests => 1;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $perlcritic = File::Spec->rel2abs( File::Spec->catfile( qw( blib script perlcritic ) ) );

--- a/t/08_document.t
+++ b/t/08_document.t
@@ -4,22 +4,22 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Carp qw< carp >;
+use Carp qw( carp );
 
 use version;
 
 
 use Perl::Critic::Document qw< >;
-use Perl::Critic::Utils qw< $EMPTY >;
-use Perl::Critic::Utils::DataConversion qw< dor >;
+use Perl::Critic::Utils ();
+use Perl::Critic::Utils::DataConversion qw( dor );
 
 
-use Test::Deep;
+use Test::Deep qw( bag cmp_deeply );
 use Test::More tests => 43;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 can_ok('Perl::Critic::Document', 'new');

--- a/t/09_theme.t
+++ b/t/09_theme.t
@@ -6,18 +6,17 @@ use warnings;
 
 use English qw(-no_match_vars);
 
-use List::MoreUtils qw(any all none);
+use List::MoreUtils qw( all any none );
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 use Perl::Critic::PolicyFactory;
 use Perl::Critic::UserProfile;
-use Perl::Critic::Theme;
+use Perl::Critic::Theme ();
 
 use Test::More tests => 66;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 ILLEGAL_RULES: {

--- a/t/10_user_profile.t
+++ b/t/10_user_profile.t
@@ -12,7 +12,7 @@ use Test::More tests => 41;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 # Create profile from hash

--- a/t/11_policy_factory.t
+++ b/t/11_policy_factory.t
@@ -8,7 +8,7 @@ use English qw(-no_match_vars);
 
 use Perl::Critic::UserProfile;
 use Perl::Critic::PolicyFactory (-test => 1);
-use Perl::Critic::TestUtils qw();
+use Perl::Critic::TestUtils ();
 
 use Test::More tests => 10;
 

--- a/t/12_policy_listing.t
+++ b/t/12_policy_listing.t
@@ -12,7 +12,7 @@ use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $profile = Perl::Critic::UserProfile->new( -profile => 'NONE' );

--- a/t/14_policy_parameter_behavior_boolean.t
+++ b/t/14_policy_parameter_behavior_boolean.t
@@ -7,14 +7,14 @@ use warnings;
 use English qw(-no_match_vars);
 
 use Perl::Critic::Policy;
-use Perl::Critic::PolicyParameter;
+use Perl::Critic::PolicyParameter ();
 use Perl::Critic::Utils qw{ :booleans };
 
 use Test::More tests => 9;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $specification;

--- a/t/14_policy_parameter_behavior_enumeration.t
+++ b/t/14_policy_parameter_behavior_enumeration.t
@@ -7,13 +7,13 @@ use warnings;
 use English qw(-no_match_vars);
 
 use Perl::Critic::Policy;
-use Perl::Critic::PolicyParameter;
+use Perl::Critic::PolicyParameter ();
 
 use Test::More tests => 24;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $specification;

--- a/t/14_policy_parameter_behavior_integer.t
+++ b/t/14_policy_parameter_behavior_integer.t
@@ -7,14 +7,14 @@ use warnings;
 use English qw(-no_match_vars);
 
 use Perl::Critic::Policy;
-use Perl::Critic::PolicyParameter;
+use Perl::Critic::PolicyParameter ();
 use Perl::Critic::Utils qw{ :booleans };
 
 use Test::More tests => 22;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $specification;

--- a/t/14_policy_parameter_behavior_list_string.t
+++ b/t/14_policy_parameter_behavior_list_string.t
@@ -5,13 +5,13 @@ use strict;
 use warnings;
 
 use Perl::Critic::Policy;
-use Perl::Critic::PolicyParameter;
+use Perl::Critic::PolicyParameter ();
 
 use Test::More tests => 28;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $specification;

--- a/t/14_policy_parameter_behavior_string.t
+++ b/t/14_policy_parameter_behavior_string.t
@@ -5,13 +5,13 @@ use strict;
 use warnings;
 
 use Perl::Critic::Policy;
-use Perl::Critic::PolicyParameter;
+use Perl::Critic::PolicyParameter ();
 
 use Test::More tests => 4;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my $specification;

--- a/t/14_policy_parameters.t
+++ b/t/14_policy_parameters.t
@@ -8,9 +8,9 @@ use English qw(-no_match_vars);
 
 use Perl::Critic::UserProfile qw();
 use Perl::Critic::PolicyFactory (-test => 1);
-use Perl::Critic::PolicyParameter qw{ $NO_DESCRIPTION_AVAILABLE };
+use Perl::Critic::PolicyParameter qw( $NO_DESCRIPTION_AVAILABLE );
 use Perl::Critic::Utils qw( policy_short_name );
-use Perl::Critic::TestUtils qw(bundled_policy_names);
+use Perl::Critic::TestUtils qw( bundled_policy_names );
 
 use Test::More; #plan set below!
 

--- a/t/15_statistics.t
+++ b/t/15_statistics.t
@@ -6,7 +6,7 @@ use warnings;
 
 use Perl::Critic::PolicyFactory (-test => 1);
 use Perl::Critic::Statistics;
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 
 use Test::More tests => 24;
 

--- a/t/20_policies.t
+++ b/t/20_policies.t
@@ -5,11 +5,11 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Test::Perl::Critic::Policy qw< all_policies_ok >;
+use Test::Perl::Critic::Policy qw( all_policies_ok );
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 # Notice that you can pass arguments to this test, which limit the testing to

--- a/t/20_policy_pod_spelling.t
+++ b/t/20_policy_pod_spelling.t
@@ -8,8 +8,8 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Perl::Critic::TestUtils qw(pcritique);
-use Readonly;
+use Perl::Critic::TestUtils qw( pcritique );
+use Readonly ();
 
 use Test::More;
 

--- a/t/20_policy_prohibit_evil_modules.t
+++ b/t/20_policy_prohibit_evil_modules.t
@@ -4,8 +4,8 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Perl::Critic::TestUtils qw< pcritique >;
-use Perl::Critic::Utils     qw< $EMPTY >;
+use Perl::Critic::TestUtils qw( pcritique );
+use Perl::Critic::Utils qw( $EMPTY );
 
 use Test::More tests => 1;
 

--- a/t/20_policy_prohibit_hard_tabs.t
+++ b/t/20_policy_prohibit_hard_tabs.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 # common P::C testing tools
-use Perl::Critic::TestUtils qw(pcritique fcritique);
+use Perl::Critic::TestUtils qw( pcritique );
 
 use Test::More tests => 10;
 

--- a/t/20_policy_require_consistent_newlines.t
+++ b/t/20_policy_require_consistent_newlines.t
@@ -6,7 +6,7 @@ use warnings;
 
 use charnames ':full';
 
-use Perl::Critic::TestUtils qw(pcritique fcritique);
+use Perl::Critic::TestUtils qw( fcritique pcritique );
 
 use Test::More tests => 29;
 

--- a/t/20_policy_require_tidy_code.t
+++ b/t/20_policy_require_tidy_code.t
@@ -4,7 +4,7 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Perl::Critic::TestUtils qw(pcritique);
+use Perl::Critic::TestUtils qw( pcritique );
 
 use Test::More tests => 6;
 

--- a/t/92_memory_leaks.t
+++ b/t/92_memory_leaks.t
@@ -4,14 +4,14 @@ use 5.006001;
 use strict;
 use warnings;
 
-use Carp qw< confess >;
+use Carp qw( confess );
 
 use PPI::Document;
 
 use Perl::Critic::PolicyFactory -test => 1;
 use Perl::Critic::Document;
-use Perl::Critic;
-use Perl::Critic::TestUtils qw();
+use Perl::Critic ();
+use Perl::Critic::TestUtils ();
 
 use Test::More; #plan set below
 

--- a/t/gh-734.t
+++ b/t/gh-734.t
@@ -3,8 +3,8 @@
 use strict;
 use warnings;
 
-use Perl::Critic::TestUtils qw(pcritique_with_violations);
-use Readonly;
+use Perl::Critic::TestUtils qw( pcritique_with_violations );
+use Readonly ();
 
 use Test::More;
 

--- a/xt/40_criticize-code.t
+++ b/xt/40_criticize-code.t
@@ -5,10 +5,10 @@
 use strict;
 use warnings;
 
-use File::Spec qw();
+use File::Spec ();
 
 use Perl::Critic::Utils qw{ :characters };
-use Perl::Critic::TestUtils qw{ starting_points_including_examples };
+use Perl::Critic::TestUtils qw( starting_points_including_examples );
 
 # Note: "use PolicyFactory" *must* appear after "use TestUtils" for the
 # -extra-test-policies option to work.
@@ -20,12 +20,11 @@ use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------
 
-use Test::Perl::Critic;
+use Test::Perl::Critic qw( all_critic_ok );
 
 #-----------------------------------------------------------------------------
 # Set up PPI caching for speed (used primarily during development)

--- a/xt/41_criticize-policies.t
+++ b/xt/41_criticize-policies.t
@@ -7,7 +7,7 @@
 use strict;
 use warnings;
 
-use File::Spec qw<>;
+use File::Spec ();
 
 use Perl::Critic::PolicyFactory ( '-test' => 1 );
 
@@ -15,12 +15,12 @@ use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------
 
-use Test::Perl::Critic;
+use Test::Perl::Critic qw( all_critic_ok );
 
 #-----------------------------------------------------------------------------
 

--- a/xt/42_criticize-tests.t
+++ b/xt/42_criticize-tests.t
@@ -5,10 +5,10 @@
 use strict;
 use warnings;
 
-use File::Spec qw();
+use File::Spec ();
 
 use Perl::Critic::Utils qw{ :characters };
-use Perl::Critic::TestUtils qw{ starting_points_including_examples };
+use Perl::Critic::TestUtils ();
 
 # Note: "use PolicyFactory" *must* appear after "use TestUtils" for the
 # -extra-test-policies option to work.
@@ -20,12 +20,11 @@ use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------
 
-use Test::Perl::Critic;
+use Test::Perl::Critic qw( all_critic_ok );
 
 #-----------------------------------------------------------------------------
 # Set up PPI caching for speed (used primarily during development)

--- a/xt/43_criticize-run-files.t
+++ b/xt/43_criticize-run-files.t
@@ -5,18 +5,18 @@
 use strict;
 use warnings;
 
-use File::Spec qw<>;
+use File::Spec ();
 
 use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------
 
-use Test::Perl::Critic;
+use Test::Perl::Critic qw( all_critic_ok );
 
 #-----------------------------------------------------------------------------
 

--- a/xt/80_policysummary.t
+++ b/xt/80_policysummary.t
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 
 use English qw< -no_match_vars >;
-use Carp qw< confess >;
+use Carp qw( confess );
 
-use File::Spec;
+use File::Spec ();
 
 use Perl::Critic::PolicyFactory ( -test => 1 );
-use Perl::Critic::TestUtils qw{ bundled_policy_names };
+use Perl::Critic::TestUtils qw( bundled_policy_names );
 
 use Test::More;
 

--- a/xt/81_ppi_problems.t
+++ b/xt/81_ppi_problems.t
@@ -9,7 +9,7 @@ use Test::More tests => 1;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 #-----------------------------------------------------------------------------

--- a/xt/94_includes.t
+++ b/xt/94_includes.t
@@ -3,16 +3,16 @@
 use strict;
 use warnings;
 
-use Carp qw< confess >;
+use Carp qw( confess );
 
-use File::Find;
+use File::Find qw( find );
 use PPI::Document;
 
 use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 my %implied = (

--- a/xt/95_kwalitee.t
+++ b/xt/95_kwalitee.t
@@ -7,7 +7,7 @@ use Test::More;
 
 our $VERSION = '1.140';
 
-use Perl::Critic::TestUtils;
+use Perl::Critic::TestUtils ();
 Perl::Critic::TestUtils::assert_version( $VERSION );
 
 eval 'use Test::Kwalitee 1.15 tests => [ qw{ -no_symlinks } ]; 1'


### PR DESCRIPTION
I'm just testing out https://metacpan.org/pod/perlimports and I figured I'd run it against the `Perl::Critic` test suite.

I'd be interested in knowing if you find these changes useful, objectionable, a waste of time or some combination of the above. 

I've documented the motivation for these changes at https://metacpan.org/pod/App::perlimports and I'm happy to receive any and all feedback on this very much unsolicited pull request. 😄 