### PR TITLE
Add option to ignore certain statements before strictures and warnings

### DIFF
--- a/lib/Perl/Critic/Policy/TestingAndDebugging/RequireUseWarnings.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/RequireUseWarnings.pm
@@ -32,6 +32,13 @@ sub supported_parameters {
             behavior        => 'string list',
             list_always_present_values => ['warnings', @WARNINGS_EQUIVALENT_MODULES],
         },
+        {
+            name            => 'ignored_statements',
+            description     =>
+                q<Regexes of statements that are ignored when searching for violations.>,
+            default_string  => $EMPTY,
+            behavior        => 'string list'
+        },
     );
 }
 
@@ -64,6 +71,7 @@ sub violates {
     for my $stmnt ( @{ $stmnts_ref } ) {
         last if $stmnt->isa('PPI::Statement::End');
         last if $stmnt->isa('PPI::Statement::Data');
+        next if $self->_statement_is_ignored($stmnt);
 
         my $stmnt_line = $stmnt->location()->[0];
         if ( (! defined $warn_line) || ($stmnt_line < $warn_line) ) {
@@ -120,6 +128,16 @@ sub _statement_isnt_include_or_package {
     return 1;
 }
 
+#-----------------------------------------------------------------------------
+
+sub _statement_is_ignored {
+    my ($self, $elem) = @_;
+    for my $ignored_stmnt ( keys %{ $self->{_ignored_statements} } ) {
+        return 1 if $elem =~ /$ignored_stmnt/;
+    }
+    return 0;
+}
+
 1;
 
 __END__
@@ -172,6 +190,13 @@ pragmata and modules in your F<.perlcriticrc>: C<equivalent_modules>.
 
     [TestingAndDebugging::RequireUseWarnings]
     equivalent_modules = MooseX::My::Sugar
+
+You may want to use certain statements before warnings are enabled.
+There is an option to specify ignored statements as regexes in your
+F<.perlcriticrc>: C<ignored_statements>.
+
+    [TestingAndDebugging::RequireUseWarnings]
+    ignored_statements = ^env\s*=>.+$
 
 
 =head1 BUGS


### PR DESCRIPTION
### Background

- We use the `TestingAndDebugging::RequireUseStrict.pm` and `TestingAndDebugging::RequireUseWarnings.pm` policies together with Moose in the source code, rendering explicit `use strict;` and `use warnings;` statements obsolete.
- We use the `Devel::StealthDebug` package which is loaded via `use Devel::StealthDebug ( env => 'test' );` where `'test'` defines an environment that can be used for log filtering.
- As an internal convention, Devel::StealthDebug is always loaded first.

### Example

```
package xyz;

use Devel::StealthDebug ( env => 'test' );
use Moose;

1;
```

Perl-Critic critiques code before strictures/warnings are enabled because of the `env => 'test'` statement.

### Proposed Changes

Allow the configuration of ignored statements that are allowed before strictures/warnings are enabled via the new configuration option `ignored_statements`.