### PR TITLE
Dependency listing cleanups

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,8 @@ use lib 'inc';
 
 use Perl::Critic::BuildUtilities qw<
     required_module_versions
-    build_required_module_versions
+    test_required_module_versions
+    configure_required_module_versions
     emit_tar_warning_if_necessary
     get_PL_files
 >;
@@ -32,13 +33,11 @@ my $builder = Perl::Critic::Module::Build->new(
     sign                => 0,
 
     requires            => { required_module_versions() },
-    build_requires      => { build_required_module_versions() },
+    test_requires       => { test_required_module_versions() },
 
     # Don't require a developer version of Module::Build, even if the
     # distribution tarball was created with one.  (Oops.)
-    configure_requires  => {
-        'Module::Build' => '0.4204',
-    },
+    configure_requires  => { configure_required_module_versions() },
 
     PL_files            => get_PL_files(),
 

--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -12,7 +12,8 @@ use Exporter 'import';
 
 our @EXPORT_OK = qw<
     required_module_versions
-    build_required_module_versions
+    test_required_module_versions
+    configure_required_module_versions
     emit_tar_warning_if_necessary
     get_PL_files
 >;
@@ -42,7 +43,6 @@ sub required_module_versions {
         'IPC::Open2'                    => 1,
         'List::MoreUtils'               => 0.19,
         'List::Util'                    => 0,
-        'Module::Build'                 => 0.4204,
         'Module::Pluggable'             => 3.1,
         'PPI'                           => '1.265',
         'PPI::Document'                 => '1.265',
@@ -79,11 +79,23 @@ sub required_module_versions {
 }
 
 
-sub build_required_module_versions {
+sub test_required_module_versions {
     return (
-        'lib'           => 0,
         'Test::Deep'    => 0,
         'Test::More'    => 0,
+        'lib'           => 0,
+    );
+}
+
+
+sub configure_required_module_versions {
+    return (
+        'Carp'          => 0,
+        'English'       => 0,
+        'Exporter'      => '5.63',
+        'Module::Build' => '0.4204',
+        'base'          => 0,
+        'lib'           => 0,
     );
 }
 


### PR DESCRIPTION
- Declare Build.PL requirements as configure requires

Modules required to run Build.PL must be specified as configure requires so that they're installed before Build.PL is run, in order to generate the build/test/runtime requirements to install. This mostly hasn't been a problem because these are all core modules aside from the modules included in inc/, and Module::Build which was manually specified. But since these core modules are being listed as runtime requirements, it seems more consistent to include them as configure requirements as well.

It would be a good idea in the future to replace the bundled Devel::CheckOS with a configure requirement though.

- Declare test requirements as test requires, not build requires

The required Module::Build version is more than sufficient to support test_requires, which is what the dependencies currently listed in build_requires are actually for. Fixing this means that these dependencies can be properly omitted by installers when not running tests.

- Declare Module::Build as configure requires, not runtime requires

This seems to have been added to the runtime requirements for appveyor in [this commit](https://github.com/Perl-Critic/Perl-Critic/commit/f98f7792a1e9cedb9ec459cf8a5c99793823093c), but it is not a runtime requirement, and the CI is now using the cpanfile to install deps instead.