### PR TITLE
Remove -V as a valid flag for version in perlcritic doc

### DIFF
--- a/bin/perlcritic
+++ b/bin/perlcritic
@@ -508,8 +508,6 @@ Displays the complete C<perlcritic> manual and exits.
 
 =item C<--version>
 
-=item C<-V>
-
 Displays the version number of C<perlcritic> and exits.
 
 =back


### PR DESCRIPTION
Presumably stopped working in v1.088 (released 2008-07-04) with the rename of
`--Version` to `--version` in eb4540f0.  `-v` is ambiguous with `--verbose`.

----

I don't think I saw any tests for the `version` flag in 07_command.t, wouldn't think that it's worth it.