### PR TITLE
Allow lexical subroutines to be inside subroutines

### DIFF
--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitNestedSubs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitNestedSubs.pm
@@ -29,20 +29,17 @@ sub applies_to           { return 'PPI::Statement::Sub' }
 sub violates {
     my ($self, $elem, $doc) = @_;
 
-    return if $elem->isa('PPI::Statement::Scheduled');
+    return if $elem->isa('PPI::Statement::Scheduled') || defined $elem->type;
 
-    my $inner = $elem->find_first(
-        sub {
-            return
-                    $_[1]->isa('PPI::Statement::Sub')
-                &&  ! $_[1]->isa('PPI::Statement::Scheduled')
-                &&  ! defined $_[1]->type;
-        }
-    );
-    return if not $inner;
+    my $outer = $elem;
+    while ($outer = $outer->parent) {
+        last if $outer->isa('PPI::Statement::Sub')
+            &&  ! $outer->isa('PPI::Statement::Scheduled');
+    }
+    return if not $outer;
 
     # Must be a violation...
-    return $self->violation($DESC, $EXPL, $inner);
+    return $self->violation($DESC, $EXPL, $elem);
 }
 
 1;

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitNestedSubs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitNestedSubs.pm
@@ -35,7 +35,8 @@ sub violates {
         sub {
             return
                     $_[1]->isa('PPI::Statement::Sub')
-                &&  ! $_[1]->isa('PPI::Statement::Scheduled');
+                &&  ! $_[1]->isa('PPI::Statement::Scheduled')
+                &&  ! defined $_[1]->type;
         }
     );
     return if not $inner;

--- a/t/Subroutines/ProhibitNestedSubs.run
+++ b/t/Subroutines/ProhibitNestedSubs.run
@@ -62,7 +62,62 @@ sub quack {
 
 sub foo {
     my sub bar { 1 }
-    my sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations inside lexical subroutine declarations.
+## failures 1
+## cut
+
+my sub foo {
+    sub bar { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside lexical subroutine declarations.
+## failures 0
+## cut
+
+my sub foo {
+    my sub bar { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations inside subroutine declarations inside subroutine declarations.
+## failures 2
+## cut
+
+sub foo {
+    sub bar {
+        sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside subroutine declarations inside subroutine declarations.
+## failures 1
+## cut
+
+sub foo {
+    sub bar {
+        my sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations inside lexical subroutine declarations inside subroutine declarations.
+## failures 1
+## cut
+
+sub foo {
+    my sub bar {
+        sub baz { 1 }
+    }
 }
 
 #-----------------------------------------------------------------------------
@@ -79,12 +134,138 @@ sub foo {
 
 #-----------------------------------------------------------------------------
 
-## name Subroutine declarations inside lexical subroutine declarations.
+## name Subroutine declarations inside subroutine declarations inside lexical subroutine declarations.
+## failures 2
+## cut
+
+my sub foo {
+    sub bar {
+        sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside subroutine declarations inside lexical subroutine declarations.
+## failures 1
+## cut
+
+my sub foo {
+    sub bar {
+        my sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations inside lexical subroutine declarations inside lexical subroutine declarations.
+## failures 1
+## cut
+
+my sub foo {
+    my sub bar {
+        sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside lexical subroutine declarations inside lexical subroutine declarations.
+## failures 0
+## cut
+
+my sub foo {
+    my sub bar {
+        my sub baz { 1 }
+    }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Multiple subroutine declarations inside subroutine declarations.
+## failures 2
+## cut
+
+sub foo {
+    sub bar { 1 }
+    sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations and lexical subroutine declarations inside subroutine declarations.
+## failures 1
+## cut
+
+sub foo {
+    sub bar { 1 }
+    my sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations and subroutine declarations inside subroutine declarations.
+## failures 1
+## cut
+
+sub foo {
+    my sub bar { 1 }
+    sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Multiple lexical subroutine declarations inside subroutine declarations.
+## failures 0
+## cut
+
+sub foo {
+    my sub bar { 1 }
+    my sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Multiple subroutine declarations inside lexical subroutine declarations.
+## failures 2
+## cut
+
+my sub foo {
+    sub bar { 1 }
+    sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations and lexical subroutine declarations inside lexical subroutine declarations.
 ## failures 1
 ## cut
 
 my sub foo {
     sub bar { 1 }
+    my sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations and subroutine declarations inside lexical subroutine declarations.
+## failures 1
+## cut
+
+my sub foo {
+    my sub bar { 1 }
+    sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Multiple lexical subroutine declarations inside lexical subroutine declarations.
+## failures 0
+## cut
+
+my sub foo {
+    my sub bar { 1 }
+    my sub baz { 1 }
 }
 
 #-----------------------------------------------------------------------------

--- a/t/Subroutines/ProhibitNestedSubs.run
+++ b/t/Subroutines/ProhibitNestedSubs.run
@@ -62,6 +62,19 @@ sub quack {
 
 sub foo {
     my sub bar { 1 }
+    my sub baz { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside lexical subroutine declarations inside subroutine declarations.
+## failures 0
+## cut
+
+sub foo {
+    my sub bar {
+        my sub baz { 1 }
+    }
 }
 
 #-----------------------------------------------------------------------------

--- a/t/Subroutines/ProhibitNestedSubs.run
+++ b/t/Subroutines/ProhibitNestedSubs.run
@@ -55,6 +55,26 @@ sub quack {
 }
 
 #-----------------------------------------------------------------------------
+
+## name Lexical subroutine declarations inside subroutine declarations.
+## failures 0
+## cut
+
+sub foo {
+    my sub bar { 1 }
+}
+
+#-----------------------------------------------------------------------------
+
+## name Subroutine declarations inside lexical subroutine declarations.
+## failures 1
+## cut
+
+my sub foo {
+    sub bar { 1 }
+}
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
Lexical subroutines should be allowed to be inside other subroutines.

Fixes #946.

Fixed #972.