### PR TITLE
Stop improper violation for lexical subroutines in Subroutines::ProhibitBuiltinHomonyms

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@
 # https://metacpan.org/release/Module-CPANfile
 # https://metacpan.org/pod/distribution/Module-CPANfile/lib/cpanfile.pod
 
-requires 'B::Keywords'                => '1.05';
+requires 'B::Keywords'                => '1.23';
 requires 'Carp'                       => 0;
 requires 'Config::Tiny'               => 2;
 requires 'English'                    => 0;

--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -24,7 +24,7 @@ use Devel::CheckOS qw< os_is >;
 
 sub required_module_versions {
     return (
-        'B::Keywords'                   => 1.05,
+        'B::Keywords'                   => 1.23,
         'Carp'                          => 0,
         'Config::Tiny'                  => 2,
         'English'                       => 0,

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
@@ -31,7 +31,18 @@ sub applies_to           { return 'PPI::Statement::Sub' }
 sub violates {
     my ( $self, $elem, undef ) = @_;
     return if $elem->isa('PPI::Statement::Scheduled'); #e.g. BEGIN, INIT, END
-    return if exists $ALLOW{ $elem->name() };
+
+    my $name = $elem->name();
+
+    # PPI 1.270 returns wrong name for lexical subroutines.
+    # We can remove this workaround when
+    # https://github.com/Perl-Critic/PPI/issues/260 is resolved.
+    if ( $name eq 'sub' and defined $elem->type() ) {
+        my $token = $elem->schild(2);
+        $name = $token->content()
+            if defined $token and $token->isa('PPI::Token::Word');
+    }
+    return if exists $ALLOW{ $name } and not defined $elem->type();
 
     my $homonym_type = $EMPTY;
     if ( is_perl_builtin( $elem ) ) {
@@ -44,7 +55,7 @@ sub violates {
         return;    #ok!
     }
 
-    my $desc = sprintf $DESC, $homonym_type, $elem->name();
+    my $desc = sprintf $DESC, $homonym_type, $name;
     return $self->violation($desc, $EXPL, $elem);
 }
 

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
@@ -14,7 +14,7 @@ our $VERSION = '1.140';
 
 #-----------------------------------------------------------------------------
 
-Readonly::Array my @ALLOW => qw( import AUTOLOAD DESTROY );
+Readonly::Array my @ALLOW => qw( import unimport AUTOLOAD DESTROY );
 Readonly::Hash my %ALLOW => hashify( @ALLOW );
 Readonly::Scalar my $DESC  => q{Subroutine name is a homonym for builtin %s %s};
 Readonly::Scalar my $EXPL  => [177];

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -347,7 +347,17 @@ sub _name_for_sub_or_stringified_element {
     my $elem = shift;
 
     if ( blessed $elem and $elem->isa('PPI::Statement::Sub') ) {
-        return $elem->name();
+        my $name = $elem->name();
+
+        # PPI 1.270 returns wrong name for lexical subroutines.
+        # We can remove this workaround when
+        # https://github.com/Perl-Critic/PPI/issues/260 is resolved.
+        if ( $name eq 'sub' and defined $elem->type() ) {
+            my $token = $elem->schild(2);
+            $name = $token->content()
+                if defined $token and $token->isa('PPI::Token::Word');
+        }
+        return $name;
     }
 
     return "$elem";

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -377,7 +377,10 @@ sub is_perl_builtin {
 
 #-----------------------------------------------------------------------------
 
-Readonly::Hash my %BAREWORDS => hashify( @B::Keywords::Barewords );
+Readonly::Hash my %BAREWORDS => hashify(
+    @B::Keywords::Barewords,
+    @B::Keywords::BarewordsExtra,
+);
 
 sub is_perl_bareword {
     my $elem = shift;

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 156;
+use Test::More tests => 158;
 
 our $VERSION = '1.140';
 
@@ -213,6 +213,16 @@ sub test_is_perl_builtin {
     $doc = make_doc( $code );
     $sub = $doc->find_first('Statement::Sub');
     ok( !is_perl_builtin($sub), 'Is not perl builtin function (PPI)' );
+
+    $code = 'my sub print {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( is_perl_builtin($sub), 'Is perl builtin function (PPI, lexial subroutines)' );
+
+    $code = 'my sub foobar {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( !is_perl_builtin($sub), 'Is not perl builtin function (PPI, lexial subroutines)' );
 
     return;
 }

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -18,7 +18,7 @@ use Perl::Critic::PolicyFactory;
 use Perl::Critic::TestUtils qw(bundled_policy_names);
 use Perl::Critic::Utils;
 
-use Test::More tests => 158;
+use Test::More tests => 168;
 
 our $VERSION = '1.140';
 
@@ -32,6 +32,7 @@ test_is_hash_key();
 test_is_script();
 test_is_script_with_PL_files();
 test_is_perl_builtin();
+test_is_perl_bareword();
 test_is_perl_global();
 test_precedence_of();
 test_is_subroutine_name();
@@ -54,6 +55,7 @@ sub test_export {
     can_ok('main', 'is_hash_key');
     can_ok('main', 'is_method_call');
     can_ok('main', 'is_perl_builtin');
+    can_ok('main', 'is_perl_bareword');
     can_ok('main', 'is_perl_global');
     can_ok('main', 'is_script');
     can_ok('main', 'is_subroutine_name');
@@ -223,6 +225,46 @@ sub test_is_perl_builtin {
     $doc = make_doc( $code );
     $sub = $doc->find_first('Statement::Sub');
     ok( !is_perl_builtin($sub), 'Is not perl builtin function (PPI, lexial subroutines)' );
+
+    return;
+}
+
+#-----------------------------------------------------------------------------
+
+sub test_is_perl_bareword {
+    ok(  is_perl_bareword('if'),     'Is perl bareword'       );
+    ok(  is_perl_bareword('import'), 'Is perl extra bareword' );
+    ok( !is_perl_bareword('foobar'), 'Is not perl bareword'   );
+
+    my $code = 'sub if {}';
+    my $doc = make_doc( $code );
+    my $sub = $doc->find_first('Statement::Sub');
+    ok( is_perl_bareword($sub), 'Is perl bareword (PPI)' );
+
+    $code = 'sub import {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( is_perl_bareword($sub), 'Is perl extra bareword (PPI)' );
+
+    $code = 'sub foobar {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( !is_perl_bareword($sub), 'Is not perl bareword (PPI)' );
+
+    $code = 'my sub if {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( is_perl_bareword($sub), 'Is perl bareword (PPI, lexial subroutines)' );
+
+    $code = 'my sub import {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( is_perl_bareword($sub), 'Is perl extra bareword (PPI, lexial subroutines)' );
+
+    $code = 'my sub foobar {}';
+    $doc = make_doc( $code );
+    $sub = $doc->find_first('Statement::Sub');
+    ok( !is_perl_bareword($sub), 'Is not perl bareword (PPI, lexial subroutines)' );
 
     return;
 }

--- a/t/Subroutines/ProhibitBuiltinHomonyms.run
+++ b/t/Subroutines/ProhibitBuiltinHomonyms.run
@@ -35,6 +35,44 @@ CHECK { do_something(); }
 END   { do_something(); }
 
 #-----------------------------------------------------------------------------
+
+## name Lexical subroutines with builtin names
+## failures 7
+## cut
+
+my sub open {}
+my sub map {}
+my sub eval {}
+my sub if {}
+my sub sub {}
+my sub foreach {}
+my sub while {}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutines with custom names
+## failures 0
+## cut
+
+my sub my_open {}
+my sub my_map {}
+my sub eval2 {}
+
+#-----------------------------------------------------------------------------
+
+## name Lexical subroutines with special names
+## failures 7
+## cut
+
+my sub import   { do_something(); }
+my sub AUTOLOAD { do_something(); }
+my sub DESTROY  { do_something(); }
+my sub BEGIN    { do_something(); }
+my sub INIT     { do_something(); }
+my sub CHECK    { do_something(); }
+my sub END      { do_something(); }
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4

--- a/t/Subroutines/ProhibitBuiltinHomonyms.run
+++ b/t/Subroutines/ProhibitBuiltinHomonyms.run
@@ -27,6 +27,7 @@ sub eval2 {}
 ## cut
 
 sub import   { do_something(); }
+sub unimport { do_something(); }
 sub AUTOLOAD { do_something(); }
 sub DESTROY  { do_something(); }
 BEGIN { do_something(); }
@@ -61,10 +62,11 @@ my sub eval2 {}
 #-----------------------------------------------------------------------------
 
 ## name Lexical subroutines with special names
-## failures 7
+## failures 8
 ## cut
 
 my sub import   { do_something(); }
+my sub unimport { do_something(); }
 my sub AUTOLOAD { do_something(); }
 my sub DESTROY  { do_something(); }
 my sub BEGIN    { do_something(); }


### PR DESCRIPTION
`Subroutines::ProhibitBuiltinHomonyms` policy incorrectly emits violation for lexical subroutine whose name is not same as builtin functions. Running the following code:

```perl
use Perl::Critic;
my $critic = Perl::Critic->new('-single-policy' => 'Subroutines::ProhibitBuiltinHomonyms');
my @violations = $critic->critique(\'my sub foo { 1 }');
print @violations;
```

Actual result: a violation `Subroutine name is a homonym for builtin keyword sub at line 1, column 1. See page 177 of PBP.` is printed.

Expected result: no violation is printed.

Fixes #955.

Fixes #546.