### PR TITLE
Fix Insecure dependency error in all_perl_files() when running with -T switch

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -1102,6 +1102,7 @@ sub all_perl_files {
                 }
                 return;
             },
+            untaint => 1,
         },
         @arg,
     );


### PR DESCRIPTION
This is a fix for issue #982 

This patch adds the untaint option to the call to File::Find::find
