### PR TITLE
fix TestingAndDebugging::RequireUseStrict policy for perl v5.36

### DIFF
--- a/lib/Perl/Critic/Policy/TestingAndDebugging/RequireUseWarnings.pm
+++ b/lib/Perl/Critic/Policy/TestingAndDebugging/RequireUseWarnings.pm
@@ -19,6 +19,7 @@ Readonly::Scalar my $DESC => q{Code before warnings are enabled};
 Readonly::Scalar my $EXPL => [431];
 
 Readonly::Scalar my $MINIMUM_VERSION => version->new(5.006);
+Readonly::Scalar my $PERL_VERSION_WHICH_IMPLIES_WARNINGS => version->new(5.036);
 
 #-----------------------------------------------------------------------------
 
@@ -47,7 +48,7 @@ sub violates {
     my ( $self, undef, $document ) = @_;
 
     my $version = $document->highest_explicit_perl_version();
-    return if $version and $version < $MINIMUM_VERSION;
+    return if $version and ($version < $MINIMUM_VERSION or $version >= $PERL_VERSION_WHICH_IMPLIES_WARNINGS);
 
     # Find the first 'use warnings' statement
     my $warn_stmnt = $document->find_first( $self->_generate_is_use_warnings() );

--- a/t/TestingAndDebugging/RequireUseWarnings.run
+++ b/t/TestingAndDebugging/RequireUseWarnings.run
@@ -95,6 +95,15 @@ use warnings;
 
 $foo = $bar;
 
+#-----------------------------------------------------------------------------
+
+## name use warnings implied by "use v5.36"
+## failures 0
+## cut
+
+$foo = $bar;
+use v5.36;
+
 #Should not find the rest of these
 
 __END__


### PR DESCRIPTION
Perl version v5.36 if explicit version used implies `use warnings` according to [perldelta](https://perldoc.perl.org/perldelta#Core-Enhancements)