### PR TITLE
Don't define $rc_file before it needs to exist

### DIFF
--- a/lib/Perl/Critic/UserProfile.pm
+++ b/lib/Perl/Critic/UserProfile.pm
@@ -241,11 +241,11 @@ sub _load_profile_from_hash {
 
 sub _find_profile_path {
 
-    #Define default filename
-    my $rc_file = '.perlcriticrc';
-
     #Check explicit environment setting
     return $ENV{PERLCRITIC} if exists $ENV{PERLCRITIC};
+
+    #Define default filename
+    my $rc_file = '.perlcriticrc';
 
     #Check current directory
     return $rc_file if -f $rc_file;


### PR DESCRIPTION
I think this makes it a touch clearer that the PERLCRITIC env var will
short-circuit checking for an rcfile in the usual locations.
