### PR TITLE
remove IO::String dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,8 +598,6 @@ Perl::Critic requires the following modules:
 
 [File::Which](https://metacpan.org/pod/File::Which)
 
-[IO::String](https://metacpan.org/pod/IO::String)
-
 [List::SomeUtils](https://metacpan.org/pod/List::SomeUtils)
 
 [List::Util](https://metacpan.org/pod/List::Util)

--- a/TODO.pod
+++ b/TODO.pod
@@ -555,12 +555,6 @@ considering doing a special release only including this change so that the
 search.cpan.org diff tool doesn't entirely break.
 
 
-=item * Eliminate use of IO::String
-
-I'm pretty sure that opening references to scalars is in 5.6, so IO::String
-isn't necessary.
-
-
 =item * Give L<Perl::Critic::Command> a proper API.
 
 Now that we've got the guts of L<perlcritic> in there, we should make the

--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,6 @@ requires 'File::Spec::Unix'           => 0;
 requires 'File::Temp'                 => 0;
 requires 'File::Which'                => 0;
 requires 'Getopt::Long'               => 0;
-requires 'IO::String'                 => 0;
 requires 'IPC::Open2'                 => 1;
 requires 'List::SomeUtils'            => '0.55';
 requires 'List::Util'                 => 0;

--- a/inc/Perl/Critic/BuildUtilities.pm
+++ b/inc/Perl/Critic/BuildUtilities.pm
@@ -39,7 +39,6 @@ sub required_module_versions {
         'File::Temp'                    => 0,
         'File::Which'                   => 0,
         'Getopt::Long'                  => 0,
-        'IO::String'                    => 0,
         'IPC::Open2'                    => 1,
         'List::SomeUtils'               => '0.55',
         'List::Util'                    => 0,

--- a/lib/Perl/Critic.pm
+++ b/lib/Perl/Critic.pm
@@ -847,8 +847,6 @@ L<File::Spec::Unix>
 
 L<File::Which>
 
-L<IO::String>
-
 L<List::SomeUtils>
 
 L<List::Util>


### PR DESCRIPTION
IO::String was needed for perl 5.6 compatibility. Since the perl requirement has been increased to 5.10.1, it is no longer needed.