### PR TITLE
Proof-of-concept for emitting JSON for GitLab code quality reports

### DIFF
--- a/lib/Perl/Critic/Command.pm
+++ b/lib/Perl/Critic/Command.pm
@@ -146,7 +146,7 @@ sub _validate_options {
         $msg .= qq{Warning: Cannot use -noprofile with -profile option.\n};
     }
 
-    if ( $opts{-verbose} && $opts{-verbose} !~ m{(?: \d+ | %[mfFlcCedrpPs] )}xms) {
+    if ( $opts{-verbose} && $opts{-verbose} !~ m{(?: \d+ | %[mfFlcCedrpPsJ] )}xms) {
         $msg .= qq<Warning: --verbose arg "$opts{-verbose}" looks odd.  >;
         $msg .= qq<Perhaps you meant to say "--verbose 3 $opts{-verbose}."\n>;
     }


### PR DESCRIPTION
I’m interested in plumbing `Perl::Critic` into GitLab’s code quality feature.  GitLab expects to receive [JSON with a particular structure](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implementing-a-custom-tool).  An automated job to generate this JSON would run for each merge request, and the output would be used to highlight issues with the code in the code review interface.

I’ve hacked up the attached proof-of-concept for generating this JSON, and would be interested in your feedback.  Most obviously:

- Does this kind of functionality belong in `Perl::Critic` itself, or should it somehow be distributed separately?
- Does the approach of enabling this via a new format seem reasonable, or does it belong in, say, `Perl::Critic::Command::_render_report`?

Thanks.