### PR TITLE
Docker improvements

### DIFF
--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -5,7 +5,8 @@ RUN apk --no-cache update && \
       perl-readonly perl-dev perl-params-util perl-file-remove perl-clone \
       perl-class-inspector perl-test-deep perl-task-weaken perl-list-moreutils \
       perl-exception-class perl-module-pluggable perl-module-build \
-      perl-file-sharedir perl-path-tiny perl-class-tiny perl-config-tiny && \
+      perl-file-sharedir perl-file-sharedir-install perl-path-tiny \
+      perl-class-tiny perl-config-tiny && \
     rm -rf /var/cache/apk/*
 
 RUN cpanm B::Keywords && \

--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -10,17 +10,12 @@ RUN apk --no-cache update && \
     rm -rf /var/cache/apk/*
 
 RUN cpanm B::Keywords && \
-    cpanm Test::Object && \
-    cpanm Hook::LexWrap && \
-    cpanm Test::SubCalls && \
     cpanm PPI::Token::Quote::Single && \
     cpanm PPIx::QuoteLike && \
     cpanm PPIx::Utilities::Statement && \
     cpanm PPIx::Regexp && \
     cpanm String::Format && \
     cpanm Perl::Tidy && \
-    cpanm Lingua::EN::Inflect && \
-    cpanm Pod::Spell && \
     rm -rf /root/.cpanm
 
 COPY lib /usr/local/lib/perl5/site_perl

--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache update && \
       perl-class-inspector perl-test-deep perl-task-weaken perl-list-moreutils \
       perl-exception-class perl-module-pluggable perl-module-build \
       perl-file-sharedir perl-file-sharedir-install perl-path-tiny \
-      perl-class-tiny perl-config-tiny && \
+      perl-class-tiny perl-config-tiny perl-list-someutils && \
     rm -rf /var/cache/apk/*
 
 RUN cpanm B::Keywords && \


### PR DESCRIPTION
Current extras/Dockerfile produces a broken image:
```shellsession
$ docker build -t perlcritic -f extras/Dockerfile . && docker run --rm -it perlcritic
Can't locate List/SomeUtils.pm in @INC (you may need to install the List::SomeUtils module) (@INC contains: /usr/local/lib/perl5/site_perl /usr/local/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl /usr/share/perl5/core_perl) at /usr/local/lib/perl5/site_perl/Perl/Critic/Utils.pm line 18.
BEGIN failed--compilation aborted at /usr/local/lib/perl5/site_perl/Perl/Critic/Utils.pm line 18.
Compilation failed in require at /usr/local/lib/perl5/site_perl/Perl/Critic/Exception/Parse.pm line 11.
BEGIN failed--compilation aborted at /usr/local/lib/perl5/site_perl/Perl/Critic/Exception/Parse.pm line 11.
Compilation failed in require at /usr/local/lib/perl5/site_perl/Perl/Critic/Command.pm line 14.
BEGIN failed--compilation aborted at /usr/local/lib/perl5/site_perl/Perl/Critic/Command.pm line 14.
Compilation failed in require at /usr/local/bin/perlcritic line 9.
BEGIN failed--compilation aborted at /usr/local/bin/perlcritic line 9.
```

Primary motivation here is to fix that. Included are a couple of image tidying/maintenance related commits.