### PR TITLE
Docker dependency pruning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,23 +7,16 @@ RUN \
         wget \
         perl \
         perl-app-cpanminus \
-        perl-class-inspector \
-        perl-class-tiny \
         perl-clone \
         perl-config-tiny \
         perl-dev \
         perl-exception-class \
-        perl-file-remove \
-        perl-file-sharedir \
-        perl-file-sharedir-install \
         perl-list-someutils \
         perl-module-build \
         perl-module-pluggable \
         perl-params-util \
-        perl-path-tiny \
         perl-readonly \
         perl-task-weaken \
-        perl-test-deep \
     && rm -rf /var/cache/apk/*
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN \
         PPIx::Regexp \
         PPIx::Utilities::Statement \
         String::Format \
+    && apk del --purge --rdepends \
+        make \
+        wget \
+        perl-app-cpanminus \
     && rm -rf /root/.cpanm
 
 COPY lib /usr/local/lib/perl5/site_perl


### PR DESCRIPTION
See individual commits for details.

I thought I'd leave the perl-test-deep apk in, but seeing Andy listed as one of the maintainers for PPIx::Utilities at rt.cpan.org, chose to remove it. Perhaps there will be another PPIx::Utilities release sometime, current one seems to be from 2010.