### PR TITLE
Really remove perl-dev from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN \
         make \
         wget \
         perl-app-cpanminus \
+        perl-dev \
     && rm -rf /root/.cpanm
 
 COPY lib /usr/local/lib/perl5/site_perl


### PR DESCRIPTION
Missed from 99bc1da71b971d8d431b96c582cdc2c6a2dc6516.