### PR TITLE
Build and push Docker image on release tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,24 @@
+name: "Docker image"
+
+on:
+  push:
+    tags:
+      - "v[0-9]+\\.[0-9]+"
+
+jobs:
+  docker-image:
+    runs-on: "ubuntu-latest"
+    if: "github.repository_owner == 'Perl-Critic'"
+    steps:
+      - uses: "docker/setup-qemu-action@v2"
+      - uses: "docker/setup-buildx-action@v2"
+      - uses: "docker/login-action@v2"
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: "docker/build-push-action@v3"
+        with:
+          platforms: "linux/amd64,linux/arm64"
+          tags: "ghcr.io/perl-critic/perl-critic:${{ github.ref_name }}"
+          push: true


### PR DESCRIPTION
As discussed in https://github.com/Perl-Critic/Perl-Critic/issues/999.

Test workflow run in my fork for a test tag v0.000: https://github.com/scop/Perl-Critic/actions/runs/3817896051 (with "Perl-Critic" and "perl-critic" repo owner replaced by "scop" compared to this PR)

Result testable as `docker run --rm -it ghcr.io/scop/perl-critic:v0.000`

Compared to the top level `build.sh` in the current `docker` branch, this obviously uses GH actions all the way, but also more importantly builds a multiplatform image, with amd64 and arm64 in it.