### PR TITLE
Add Pod::Spell in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,13 @@ RUN \
         wget \
         perl \
         perl-app-cpanminus \
+        perl-class-tiny \
         perl-clone \
         perl-config-tiny \
         perl-dev \
         perl-exception-class \
+        perl-file-sharedir \
+        perl-file-sharedir-install \
         perl-list-someutils \
         perl-module-build \
         perl-module-pluggable \
@@ -23,6 +26,7 @@ RUN \
     cpanm --notest \
         B::Keywords \
         Perl::Tidy \
+        Pod::Spell \
         PPI::Token::Quote::Single \
         PPIx::QuoteLike \
         PPIx::Regexp \


### PR DESCRIPTION
Along with available dependencies from Alpine.

Per https://github.com/Perl-Critic/Perl-Critic/pull/1012#issuecomment-136891800