### PR TITLE
Variables::ProhibitPackageVars: add Text::Wrap to package list

### DIFF
--- a/lib/Perl/Critic/Policy/Variables/ProhibitPackageVars.pm
+++ b/lib/Perl/Critic/Policy/Variables/ProhibitPackageVars.pm
@@ -27,7 +27,7 @@ sub supported_parameters {
         {
             name            => 'packages',
             description     => 'The base set of packages to allow variables for.',
-            default_string  => 'Data::Dumper File::Find FindBin Log::Log4perl',
+            default_string  => 'Data::Dumper File::Find FindBin Log::Log4perl Text::Wrap',
             behavior        => 'string list',
         },
         {


### PR DESCRIPTION
Text::Wrap is a core module that is configured with package variables.