### PR TITLE
t/06_violation.t - do not import from PPI::Document

### DIFF
--- a/t/06_violation.t
+++ b/t/06_violation.t
@@ -8,11 +8,11 @@ use English qw< -no_match_vars >;
 
 use File::Basename qw< basename >;
 use File::Spec::Functions qw< catdir catfile >;
-use PPI::Document q< >;
-use PPI::Document::File q< >;
+use PPI::Document;
+use PPI::Document::File;
 
 use Perl::Critic::Utils qw< :characters >;
-use Perl::Critic::Violation q< >;
+use Perl::Critic::Violation;
 
 use Test::More tests => 69;
 


### PR DESCRIPTION
t/06_violation.t imports a space from various packages, some of which do not define an import() method which is capable of importing anything. In 5.39.1 and later this causes an error like this:

    Attempt to call undefined import method with arguments
    via package "PPI::Document" (Perhaps you forgot to load
    the package?) at t/06_violation.t line 11.

Which breaks the install.