### PR TITLE
Fix typo in pod

### DIFF
--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitBuiltinHomonyms.pm
@@ -102,7 +102,7 @@ as well as C<AUTOLOAD>, C<DESTROY>, and C<import> subroutines.
 You can configure additional builtin homonyms to accept by specifying them
 in a space-delimited list to the C<allow> option:
 
-    [Subroutines::ProhibitUnusedPrivateSubroutines]
+    [Subroutines::ProhibitBuiltinHomonyms]
     allow = default index
 
 These are added to the default list of exemptions from this policy. So the


### PR DESCRIPTION
Inside `ProhibitBuiltinHomonyms.pm`, change configuration doc to reflect the package name instead of `ProhibitUnusedPrivateSubroutines`.

Must have been a copy-paste error from that module.