### PR TITLE
Added SARIF format output option

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,7 @@ requires 'File::Spec::Unix'           => 0;
 requires 'File::Temp'                 => 0;
 requires 'File::Which'                => 0;
 requires 'Getopt::Long'               => 0;
+requires 'JSON'                       => '4.10';
 requires 'List::SomeUtils'            => '0.55';
 requires 'List::Util'                 => 0;
 requires 'Module::Build'              => '0.4204';


### PR DESCRIPTION
Hi 👋 

I've added [SARIF](https://sarifweb.azurewebsites.net/) output to Perl::Critic, so that the results can be used in tools that view these structured static analysis results.

One example is GitHub's Code Scanning, which accepts SARIF uploads (I work at GitHub).

The change adds:

* a new dependency on `JSON`, included in `cpanfile`
* changes to `_critique()` to add the new output option
* new functions to be called by `_critique`
* a global hash to map Perl::Critic severity levels to SARIF levels
* a new `--sarif` option to trigger the new output format

I wasn't sure which version of `JSON` to use, so set it to the latest. You might want to put it at an older version e.g. `4.00` instead of the latest.

I've tested this locally, run `Perl::Critic` over it (naturally), and the CI has run on my fork.

I haven't added tests specific to my changes; I confess I'm not very familiar with Perl tests and could do with some assistance crafting them, if they're needed.

Thanks!