### PR TITLE
(Mostly) fix Subroutines::ProhibitManyArgs when used with signatures

### DIFF
--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
@@ -56,6 +56,10 @@ sub violates {
     if ($elem->prototype) {
         my $prototype = $elem->prototype();
         if ($prototype =~ /[a-z]/i) {  # signature (probably)
+            state $c = qr/\Q$CLASS/;
+            state $s = qr/\Q$SELF/;
+            state $invocant = qr/^(?:$c|$s),?/;
+            $prototype =~ s/$invocant// if $self->{_skip_object};
             $num_args = $prototype =~ tr/$@%/$@%/;
         } else {  # prototype
             $prototype =~ s/ \\ [[] .*? []] /*/smxg;    # Allow for grouping

--- a/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
+++ b/lib/Perl/Critic/Policy/Subroutines/ProhibitManyArgs.pm
@@ -55,8 +55,12 @@ sub violates {
     my $num_args;
     if ($elem->prototype) {
         my $prototype = $elem->prototype();
-        $prototype =~ s/ \\ [[] .*? []] /*/smxg;    # Allow for grouping
-        $num_args = $prototype =~ tr/$@%&*_+/$@%&*_+/;    # RT 56627
+        if ($prototype =~ /[a-z]/i) {  # signature (probably)
+            $num_args = $prototype =~ tr/$@%/$@%/;
+        } else {  # prototype
+            $prototype =~ s/ \\ [[] .*? []] /*/smxg;    # Allow for grouping
+            $num_args = $prototype =~ tr/$@%&*_+/$@%&*_+/;    # RT 56627
+        }
     } else {
         $num_args = _count_args($self->{_skip_object}, $elem->block->schildren);
     }

--- a/t/Subroutines/ProhibitManyArgs.run
+++ b/t/Subroutines/ProhibitManyArgs.run
@@ -213,6 +213,74 @@ sub classy_self {
 }
 
 #-----------------------------------------------------------------------------
+
+# Ideally these signature tests would be protected by a test for whether the
+# perl being used supports signatures, and would ensure signatures is turned
+# on.
+
+## name signature without $self or $class - success
+## failures 0
+## parms {max_arguments => 2}
+## cut
+
+sub foo {
+}
+
+sub bar ($bar1) {
+}
+
+sub baz ($baz1, $baz2) {
+}
+
+sub qux ($qux_1, $qux_2) {
+}
+
+#-----------------------------------------------------------------------------
+
+## name signature without $self or $class -- failure
+## failures 1
+## parms {max_arguments => 2}
+## cut
+
+sub foo ($foo1, $foo2, $foo3) {
+}
+
+#-----------------------------------------------------------------------------
+
+## name signature with $self or $class -- success
+## failures 0
+## parms {skip_object => 1, max_arguments => 2}
+## cut
+
+sub foo ($class) {
+}
+
+sub bar ($self, $bar1) {
+}
+
+sub baz ($class, $baz1, $baz2) {
+}
+
+sub qux ($self, $qux_1, $qux_2) {
+}
+
+sub quux (   $self , $quux_1, $quux_2) {
+}
+
+#-----------------------------------------------------------------------------
+
+## name signature with $self or $class -- failure
+## failures 2
+## parms {skip_object => 1, max_arguments => 2}
+## cut
+
+sub foo ($self, $foo1, $foo3, $foo3) {
+}
+
+sub bar ($class, $bar_1, $bar_2, $bar_3) {
+}
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
Signatures are returned as prototypes.  For most simple cases the prototype counting works for signatures as well, but the major problem is when the signature arguments contain underscores which causes them to be counted more than once.

We can mostly distinguish between prototypes and signatures by checking for the presence of letters.  The perlsub documentation states _A valid prototype cannot contain any alphabetic character._

This should be good enough to solve the most important problem without causing too many other difficulties.  Potential problematic areas include invalid prototypes and signatures only including non-alphabetic characters:

  `perl -Mutf8 -E 'sub n ($𐠒) { say $𐠒 } n 42'`

Perhaps you could argue that here people will get what they deserve.  I suppose this is an 80% solution which might solve 99% of the problems.

This should basically solve #1027 and might feed into #591 in some form.