### PR TITLE
ProhibitUnusedCapture: fix recognising hash and enligsh array captures

### DIFF
--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
@@ -592,6 +592,7 @@ sub _mark_magic {
         ( \%CAPTURE_REFERENCE, \%CAPTURE_ARRAY );
     $elem->isa( 'PPI::Token::Magic' )
         or $capture_ref->{$content}
+        or $capture_array->{$content}
         or return;
 
     if ( $content =~ m/ \A \$ ( \d+ ) /xms ) {

--- a/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
+++ b/lib/Perl/Critic/Policy/RegularExpressions/ProhibitUnusedCapture.pm
@@ -35,6 +35,11 @@ Readonly::Hash my %CAPTURE_ARRAY => hashify( qw< @- @+ @{^CAPTURE} > );
 Readonly::Hash my %CAPTURE_ARRAY_ENGLISH => (
     hashify( qw< @LAST_MATCH_START @LAST_MATCH_END > ),
     %CAPTURE_ARRAY );
+Readonly::Hash my %CAPTURE_HASH => hashify( qw< %- %+ %{^CAPTURE} >);
+Readonly::Hash my %CAPTURE_HASH_ENGLISH => (
+    hashify( qw< %LAST_PAREN_MATCH > ),
+    %CAPTURE_HASH );
+
 
 Readonly::Scalar my $DESC => q{Only use a capturing group if you plan to use the captured value};
 Readonly::Scalar my $EXPL => [252];
@@ -587,12 +592,13 @@ sub _mark_magic {
 
     # Only interested in magic, or known English equivalent.
     my $content = $elem->content();
-    my ( $capture_ref, $capture_array ) = $doc->uses_module( 'English' ) ?
-        ( \%CAPTURE_REFERENCE_ENGLISH, \%CAPTURE_ARRAY_ENGLISH ) :
-        ( \%CAPTURE_REFERENCE, \%CAPTURE_ARRAY );
+    my ( $capture_ref, $capture_array, $capture_hash ) = $doc->uses_module( 'English' ) ?
+        ( \%CAPTURE_REFERENCE_ENGLISH, \%CAPTURE_ARRAY_ENGLISH, \%CAPTURE_HASH_ENGLISH ) :
+        ( \%CAPTURE_REFERENCE, \%CAPTURE_ARRAY, \%CAPTURE_HASH );
     $elem->isa( 'PPI::Token::Magic' )
         or $capture_ref->{$content}
         or $capture_array->{$content}
+        or $capture_hash->{$content}
         or return;
 
     if ( $content =~ m/ \A \$ ( \d+ ) /xms ) {
@@ -608,6 +614,10 @@ sub _mark_magic {
     } elsif ( $capture_array->{$content} ) {    # GitHub #778
         foreach my $num ( 1 .. @{$captures} ) {
             _record_numbered_capture( $num, $captures );
+        }
+    } elsif ( $capture_hash->{$content} ) {
+        foreach my $name ( keys %{$named_captures} ) {
+            _record_named_capture( $name, $captures, $named_captures );
         }
     } elsif ( $capture_ref->{$content} ) {
         _mark_magic_subscripted_code( $elem, $re, $captures, $named_captures );

--- a/t/RegularExpressions/ProhibitUnusedCapture.run
+++ b/t/RegularExpressions/ProhibitUnusedCapture.run
@@ -653,6 +653,46 @@ my @b = split( /x/, $1 );
 
 #-----------------------------------------------------------------------------
 
+## name %- %+ %{^CAPTURE} capture all named captures
+## failures 0
+## cut
+
+if ( m/(?<%>-)/ ) {
+    print %-;
+}
+
+if ( m/(?<%>+)/ ) {
+    print %+;
+}
+
+if ( m/(?<%>^CAPTURE))/ ) {
+    print %{^CAPTURE};
+}
+
+#-----------------------------------------------------------------------------
+
+## name %LAST_PAREN_MATCH captures all named captures
+## failures 0
+## cut
+
+use English;
+
+if ( m/(?<x>LAST_PAREN_MATCH)/ ) {
+    print %LAST_PAREN_MATCH;
+}
+
+#-----------------------------------------------------------------------------
+
+## name %+ doesn't capture unnamed captures
+## failures 1
+## cut
+
+if ( m/(foo)(?<bar>bar)/ ) {
+    print %+;
+}
+
+#-----------------------------------------------------------------------------
+
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4

--- a/t/RegularExpressions/ProhibitUnusedCapture.run
+++ b/t/RegularExpressions/ProhibitUnusedCapture.run
@@ -572,6 +572,36 @@ s/(.)/ { $1 } /e;
 
 #-----------------------------------------------------------------------------
 
+## name @- and @+
+## failures 0
+## cut
+
+if ( m/(at-minus array)/ ) {
+    print @-;
+}
+
+if ( m/(at-plus array)/ ) {
+    print @+;
+}
+
+#-----------------------------------------------------------------------------
+
+## name english @LAST_MATCH_START and @LAST_MATCH_END
+## failures 0
+## cut
+
+use English
+
+if ( m/(LAST_MATCH_START array)/ ) {
+    print @LAST_MATCH_START;
+}
+
+if ( m/(LAST_MATCH_END array)/ ) {
+    print @LAST_MATCH_END;
+}
+
+#-----------------------------------------------------------------------------
+
 ## name @{^CAPTURE} added in 5.25.7 (GitHub #778)
 ## failures 0
 ## cut
@@ -582,6 +612,7 @@ if ( m/(CAPTURE array)/ ) {
 
 if ( m/(quoted CAPTURE array)/ ) {
     print "@{^CAPTURE}\n";
+}
 
 if ( m/(CAPTURE array element)/ ) {
     print ${^CAPTURE}[0];
@@ -618,7 +649,7 @@ if ( m/(CAPTURE_ALL)/ ) {
 
 /(.+)/;
 my @a = split /x/, $1;
-my @b = split( /x/, $1;
+my @b = split( /x/, $1 );
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
There was no handling of unsubscripted `%+`, `%-` `%{^CAPTURE}` or the English `%LAST_PAREN_MATCH`.

Also, the English `@LAST_MATCH_START` and `@LAST_MATCH_END` arrays were not being recognised because they're not `PPI::Token::Magic`.

In passing, add some tests for `@-` and `@+`, which had no tests for the unsubscripted case.