### PR TITLE
Allow a `use VERSION` statement to appear before the `package` line

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ NEXT
     Fixed a deprecation warning in the extras/perlcritic.el Emacs script.
     Thanks, Rolf Stöckli. (GH #1067)
 
+    RequireExplicitPackage now accepts a use VERSION as the first line.
+    Thanks, Philippe Bruhat. (GH #1070)
+
     [Documentation]
     Clarify C<package_exemptions> rules.  Thanks, Felix Ostmann. (GH #1043)
 

--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
@@ -129,6 +129,11 @@ There are some valid reasons for not having a C<package> statement at
 all.  But make sure you understand them before assuming that you
 should do it too.
 
+One of those reasons is having a C<use VERSION> line as the first line
+of your Perl file. It I<declares> which version of the Perl language
+the following code is written. Because the effect is lexical, the previous
+remarks about the caller's package do not apply.
+
 The maximum number of violations per document for this policy defaults
 to 1.
 

--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitPackage.pm
@@ -90,6 +90,9 @@ sub _is_statement_of_interest {
             $self->{_allow_import_of}{$module}
                 and return $FALSE;
         }
+        elsif ( $elem->version ) {
+            return $FALSE;
+        }
     }
 
     return $TRUE;

--- a/t/Modules/RequireExplicitPackage.run
+++ b/t/Modules/RequireExplicitPackage.run
@@ -119,6 +119,28 @@ use utf8;
 package Foo::Bar;
 
 #-----------------------------------------------------------------------------
+
+## name Allow line 1 version semantics
+## failures 0
+## cut
+
+use v5.36;
+
+package Foo::Bar;
+
+#-----------------------------------------------------------------------------
+
+## name Allow line 1 version semantics and specific modules
+## failures 0
+## parms { allow_import_of => 'utf8' }
+## cut
+
+use v5.36;
+use utf8;
+
+package Foo::Bar;
+
+#-----------------------------------------------------------------------------
 # Local Variables:
 #   mode: cperl
 #   cperl-indent-level: 4


### PR DESCRIPTION
The Perl Steering Council has been promoting the idea of Perl being useful "from line 1", i.e. add `use v5.36;` as the first line of your code, and you get the most useful Perl you can get.

Having `use v5.36;` as the first line of your code competes withe having `package` as the first line of your code.

This patch adds an exception for `use version` to be allowed to appear first, before the `package` line.