### PR TITLE
Try to address is_hash_key false positive on function call inside hash index

### DIFF
--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -717,7 +717,7 @@ sub is_hash_key {
     return
         $sib
         && $sib->isa('PPI::Token::Operator')
-        && $sib eq '=>'
+        && $sib eq $FATCOMMA
     ;
 }
 

--- a/lib/Perl/Critic/Utils.pm
+++ b/lib/Perl/Critic/Utils.pm
@@ -711,7 +711,13 @@ sub is_hash_key {
     return if !$parent;
     my $grandparent = $parent->parent();
     return if !$grandparent;
-    return 1 if $grandparent->isa('PPI::Structure::Subscript');
+    if ( $grandparent->isa('PPI::Structure::Subscript') ) {
+        #If followed by a non-(fat)comma, then it's not a hash slice,
+        #so a function call without parentheses.
+        return if $sib && !($sib->isa('PPI::Token::Operator')
+                            && ($sib eq $COMMA || $sib eq $FATCOMMA));
+        return 1;
+    }
 
     #Check declarative style: %hash = (foo => bar);
     return

--- a/t/05_utils.t
+++ b/t/05_utils.t
@@ -126,7 +126,8 @@ sub test_is_assignment_operator {
 #-----------------------------------------------------------------------------
 
 sub test_is_hash_key {
-    my $code = 'sub foo { return $h1{bar}, $h2->{baz}, $h3->{ nuts() } }';
+    my $code = 'sub foo { return $h1{bar}, $h2->{baz}, $h3->{ nuts() }, @h4{a, b(), c}, $h5{ my_fun @args } }
+my %h6 = ( d => e, f, g )';
     my $doc = PPI::Document->new(\$code);
     my @words = @{$doc->find('PPI::Token::Word')};
     my @expect = (
@@ -136,12 +137,21 @@ sub test_is_hash_key {
         ['bar', 1],
         ['baz', 1],
         ['nuts', undef],
+        ['a', 1],
+        ['b', undef],
+        ['c', 1],
+        ['my_fun', undef],
+        ['my', undef],
+        ['d', 1],
+        ['e', undef],
+        ['f', undef],
+        ['g', undef],
     );
     is(scalar @words, scalar @expect, 'is_hash_key count');
 
     for my $i (0 .. $#expect) {
         is($words[$i], $expect[$i][0], 'is_hash_key word');
-        is( !!is_hash_key($words[$i]), !!$expect[$i][1], 'is_hash_key boolean' );
+        is( !!is_hash_key($words[$i]), !!$expect[$i][1], 'is_hash_key boolean: ' . $words[$i] );
     }
 
     return;


### PR DESCRIPTION
This is my attempt at a fix for #1071. It works for my case, but I'm not sure it covers all edge cases correctly.