### PR TITLE
Add `skip_when_isa` option to `ProhibitUnusedPrivateSubroutines` policy

### DIFF
--- a/t/Subroutines/ProhibitUnusedPrivateSubroutines.run
+++ b/t/Subroutines/ProhibitUnusedPrivateSubroutines.run
@@ -235,6 +235,32 @@ sub _second {
 
 #-----------------------------------------------------------------------------
 
+## name skip_when_isa with use base
+## failures 0
+## parms { skip_when_isa => 'My::BaseClass' }
+## cut
+
+use base 'My::BaseClass';
+
+sub _private {
+    print "A private sub\n";
+}
+
+#-----------------------------------------------------------------------------
+
+## name skip_when_isa with multiple parent classes
+## failures 0
+## parms { skip_when_isa => 'First::ParentClass Other::ParentClass' }
+## cut
+
+use parent qw( Other::ParentClass Some::Class );
+
+sub _private {
+    print "A private sub\n";
+}
+
+#-----------------------------------------------------------------------------
+
 ## name skip_when_using
 ## failures 0
 ## parms { skip_when_using => 'Moose::Role' }


### PR DESCRIPTION
This PR adds a new `skip_when_isa` configuration option to the `Subroutines::ProhibitUnusedPrivateSubroutines` policy.
This option allows to specify parent classes that, when inherited from via `use parent` or `use base`, will cause the policy to skip checking private subroutines in the module.

I believe it's important to have this option, especially for older, large codebases where methods starting with an underscore (`_`) are used in child classes within specific namespaces only.

Also, I've found related request in the past - https://github.com/Perl-Critic/Perl-Critic/issues/926