### PR TITLE
Add InputOutput::RequireUseUTF8 policy

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -104,6 +104,7 @@ lib/Perl/Critic/Policy/InputOutput/RequireCheckedClose.pm
 lib/Perl/Critic/Policy/InputOutput/RequireCheckedOpen.pm
 lib/Perl/Critic/Policy/InputOutput/RequireCheckedSyscalls.pm
 lib/Perl/Critic/Policy/InputOutput/RequireEncodingWithUTF8Layer.pm
+lib/Perl/Critic/Policy/InputOutput/RequireUseUTF8.pm
 lib/Perl/Critic/Policy/Miscellanea/ProhibitFormats.pm
 lib/Perl/Critic/Policy/Miscellanea/ProhibitTies.pm
 lib/Perl/Critic/Policy/Miscellanea/ProhibitUnrestrictedNoCritic.pm
@@ -322,6 +323,7 @@ t/InputOutput/RequireCheckedClose.run
 t/InputOutput/RequireCheckedOpen.run
 t/InputOutput/RequireCheckedSyscalls.run
 t/InputOutput/RequireEncodingWithUTF8Layer.run
+t/InputOutput/RequireUseUTF8.run
 t/Miscellanea/ProhibitFormats.run
 t/Miscellanea/ProhibitTies.run
 t/Miscellanea/ProhibitUnrestrictedNoCritic.run

--- a/lib/Perl/Critic/Policy/InputOutput/RequireUseUTF8.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/RequireUseUTF8.pm
@@ -1,0 +1,212 @@
+package Perl::Critic::Policy::InputOutput::RequireUseUTF8;
+
+use 5.010001;
+use strict;
+use warnings;
+
+use version 0.77;
+use Readonly;
+use Scalar::Util qw{ blessed };
+
+use Perl::Critic::Utils qw{ :severities $EMPTY };
+use Perl::Critic::Utils::Constants qw{ :equivalent_modules };
+use parent 'Perl::Critic::Policy';
+
+our $VERSION = '1.156';
+
+#-----------------------------------------------------------------------------
+
+Readonly::Scalar my $DESC => q{Code before utf8 is enabled};
+Readonly::Scalar my $EXPL => [ 429 ];
+
+#-----------------------------------------------------------------------------
+
+sub supported_parameters {
+    return (
+        {
+            name            => 'equivalent_modules',
+            description     =>
+                q<The additional modules to treat as equivalent to "utf8".>,
+            default_string  => $EMPTY,
+            behavior        => 'string list',
+            list_always_present_values => ['utf8', @UTF8_EQUIVALENT_MODULES],
+        },
+    );
+}
+
+sub default_severity     { return $SEVERITY_HIGH        }
+sub default_themes       { return qw( core bugs )     }
+sub applies_to           { return 'PPI::Document'     }
+
+sub default_maximum_violations_per_document { return 1; }
+
+#-----------------------------------------------------------------------------
+
+sub violates {
+    my ( $self, undef, $doc ) = @_;
+
+    # Find the first 'use utf8' statement
+    my $utf8_stmnt = $doc->find_first( $self->_generate_is_use_utf8() );
+    my $utf8_line  = $utf8_stmnt ? $utf8_stmnt->location()->[0] : undef;
+
+    # Find all statements that aren't 'use', 'require', or 'package'
+    my $stmnts_ref = _find_isnt_include_or_package($doc);
+    return if not $stmnts_ref;
+
+    # If the 'use utf8' statement is not defined, or the other
+    # statement appears before the 'use utf8', then it violates.
+
+    my @viols;
+    for my $stmnt ( @{ $stmnts_ref } ) {
+        last if $stmnt->isa('PPI::Statement::End');
+        last if $stmnt->isa('PPI::Statement::Data');
+
+        my $stmnt_line = $stmnt->location()->[0];
+        if ( (! defined $utf8_line) || ($stmnt_line < $utf8_line) ) {
+            push @viols, $self->violation( $DESC, $EXPL, $stmnt );
+        }
+    }
+    return @viols;
+}
+
+#-----------------------------------------------------------------------------
+
+sub _generate_is_use_utf8 {
+    my ($self) = @_;
+
+    return sub {
+        my (undef, $elem) = @_;
+
+        return 0 if !$elem->isa('PPI::Statement::Include');
+        return 0 if $elem->type() ne 'use';
+
+        # We only want file-scoped pragmas
+        my $parent = $elem->parent();
+        return 0 if !$parent->isa('PPI::Document');
+
+        if ( my $pragma = $elem->pragma() ) {
+            return 1 if $self->{_equivalent_modules}{$pragma};
+        }
+        elsif ( my $module = $elem->module() ) {
+            # Special case: use source::encoding 'utf8' (Perl 5.41+)
+            if ( $module eq 'source::encoding' ) {
+                return _is_source_encoding_utf8($elem);
+            }
+            return 1 if $self->{_equivalent_modules}{$module};
+        }
+
+        return 0;
+    };
+}
+
+#-----------------------------------------------------------------------------
+
+sub _is_source_encoding_utf8 {
+    my ($elem) = @_;
+
+    # Check if the argument is 'utf8' or "utf8"
+    # use source::encoding 'utf8';
+    my @children = $elem->schildren();
+    for my $child (@children) {
+        if ( $child->isa('PPI::Token::Quote') ) {
+            my $string = $child->string();
+            return 1 if $string eq 'utf8';
+        }
+    }
+
+    return 0;
+}
+
+#-----------------------------------------------------------------------------
+# Here, we're using the fact that Perl::Critic::Document::find() is optimized
+# to search for elements based on their type.  This is faster than using the
+# native PPI::Node::find() method with a custom callback function.
+
+sub _find_isnt_include_or_package {
+    my ($doc) = @_;
+    my $all_statements = $doc->find('PPI::Statement') or return;
+    my @wanted_statements = grep { _statement_isnt_include_or_package($_) } @{$all_statements};
+    return @wanted_statements ? \@wanted_statements : ();
+}
+
+#-----------------------------------------------------------------------------
+
+sub _statement_isnt_include_or_package {
+    my ($elem) = @_;
+    return 0 if $elem->isa('PPI::Statement::Package');
+    return 0 if $elem->isa('PPI::Statement::Include');
+    return 1;
+}
+
+1;
+
+__END__
+
+#-----------------------------------------------------------------------------
+
+=pod
+
+=head1 NAME
+
+Perl::Critic::Policy::InputOutput::RequireUseUTF8 - Always C<use utf8>.
+
+
+=head1 AFFILIATION
+
+This Policy is part of the core L<Perl::Critic|Perl::Critic>
+distribution.
+
+
+=head1 DESCRIPTION
+
+Using the C<utf8> pragma ensures that string literals in your source code
+are properly interpreted as UTF-8. This policy requires that the C<'use
+utf8'> statement must come before any other statements except C<package>,
+C<require>, and other C<use> statements. Thus, all the code in the entire
+package will be affected.
+
+As of Perl 5.41, C<use source::encoding 'utf8'> is also recognized as
+equivalent to C<use utf8>.
+
+There are special exemptions for modules like L<Mojolicious::Lite|Mojolicious::Lite>
+and L<Dancer2|Dancer2> because using them enables the utf8 pragma automatically;
+e.g. C<'use Mojolicious::Lite'> enables utf8, making an explicit C<'use utf8'>
+unnecessary.
+
+The maximum number of violations per document for this policy defaults to 1.
+
+
+=head1 CONFIGURATION
+
+If you make use of things like
+L<Mojoliciouse::Lite|Mojoliciouse::Lite>, L<Dancer2|Dancer2> you can create your own modules
+that import the L<utf8|utf8> pragma into the code that is
+C<use>ing them.  There is an option to add to the default set of
+pragmata and modules in your F<.perlcriticrc>: C<equivalent_modules>.
+
+    [InputOutput::RequireUseUTF8]
+    equivalent_modules = Dancer2 Mojolicious::Lite
+
+=head1 AUTHOR
+
+Kenta Kobayashi <kfly@cpan.org>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2025 Kenta Kobayashi.  Many rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.  The full text of this license
+can be found in the LICENSE file included with this module
+
+=cut
+
+##############################################################################
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :

--- a/lib/Perl/Critic/Utils/Constants.pm
+++ b/lib/Perl/Critic/Utils/Constants.pm
@@ -27,6 +27,7 @@ our @EXPORT_OK = qw{
     $_MODULE_VERSION_TERM_ANSICOLOR
     @STRICT_EQUIVALENT_MODULES
     @WARNINGS_EQUIVALENT_MODULES
+    @UTF8_EQUIVALENT_MODULES
 };
 
 our %EXPORT_TAGS = (
@@ -53,6 +54,7 @@ our %EXPORT_TAGS = (
         qw{
            @STRICT_EQUIVALENT_MODULES
            @WARNINGS_EQUIVALENT_MODULES
+           @UTF8_EQUIVALENT_MODULES
         }
     ],
 );
@@ -132,6 +134,16 @@ Readonly::Array our @STRICT_EQUIVALENT_MODULES => qw(
 # the moment these equivalent module lists are exactly the same.
 Readonly::Array our @WARNINGS_EQUIVALENT_MODULES
     => @STRICT_EQUIVALENT_MODULES;
+
+# Modules that enable the utf8 pragma automatically.
+# Note that not all modules that enable strict/warnings also enable utf8.
+Readonly::Array our @UTF8_EQUIVALENT_MODULES => qw(
+    Dancer
+    Dancer2
+
+    Mojolicious::Lite
+    Mojo::Base
+);
 
 #-----------------------------------------------------------------------------
 
@@ -215,6 +227,13 @@ applying the L<strict|strict> or L<warnings|warnings> pragma when loaded. At
 the moment, both lists are exactly the same. B<Note:> These lists are not
 exhaustive; they only include the most commonly used modules. Policies that
 use these lists should permit configuration of additional modules.
+
+=item C<@UTF8_EQUIVALENT_MODULES>
+
+A list of modules that enable the L<utf8|utf8> pragma automatically when loaded.
+B<Note:> This list is not exhaustive; it only includes the most commonly used
+modules. Policies that use this list should permit configuration of additional
+modules.
 
 =back
 

--- a/t/03_pragmas.t
+++ b/t/03_pragmas.t
@@ -20,6 +20,7 @@ my $profile = {
     '-CodeLayout::RequireTidyCode'                               => {},
     '-Documentation::PodSpelling'                                => {},
     '-ErrorHandling::RequireCheckingReturnValueOfEval'           => {},
+    '-InputOutput::RequireUseUTF8'                               => {},
     '-Miscellanea::ProhibitUnrestrictedNoCritic'                 => {},
     '-Miscellanea::ProhibitUselessNoCritic'                      => {},
     '-ValuesAndExpressions::ProhibitMagicNumbers'                => {},

--- a/t/15_statistics.t
+++ b/t/15_statistics.t
@@ -52,7 +52,10 @@ END_PERL
 #-----------------------------------------------------------------------------
 
 # Just don't get involved with Perl::Tidy.
-my $profile = { '-CodeLayout::RequireTidyCode' => {} };
+my $profile = {
+    '-CodeLayout::RequireTidyCode' => {},
+    '-InputOutput::RequireUseUTF8' => {},
+};
 my $critic =
     Perl::Critic->new(
         -severity => 1,

--- a/t/InputOutput/RequireUseUTF8.run
+++ b/t/InputOutput/RequireUseUTF8.run
@@ -1,0 +1,208 @@
+## name one statement before utf8
+## failures 1
+## cut
+
+$foo = $bar;
+use utf8;
+
+#-----------------------------------------------------------------------------
+
+## name several statements before utf8
+## failures 1
+## cut
+
+$foo = $bar;   ## This one violates.
+$baz = $nuts;  ## no critic;  This one is exempted
+$blamo;        ## This one should be squelched
+use utf8;
+
+#-----------------------------------------------------------------------------
+
+## name several statements before utf8 with maximum violations changed
+## failures 2
+## parms { maximum_violations_per_document => 2 }
+## cut
+
+$foo = $bar;   ## This one violates.
+$baz = $nuts;  ## This one violates.
+$blamo;        ## This one should be squelched
+use utf8;
+
+#-----------------------------------------------------------------------------
+
+## name no utf8 at all
+## failures 1
+## cut
+
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name require utf8
+## failures 1
+## cut
+
+require utf8;
+1;
+
+#-----------------------------------------------------------------------------
+
+## name utf8 used, but no code
+## failures 0
+## cut
+
+use utf8;
+
+#-----------------------------------------------------------------------------
+
+## name no utf8 at all, w/END
+## failures 1
+## cut
+
+$foo = $bar;
+
+#Should not find the rest of these
+
+__END__
+
+=head1 NAME
+
+Foo - A Foo factory class
+
+=cut
+
+#-----------------------------------------------------------------------------
+
+## name no utf8 at all, w/DATA
+## failures 1
+## cut
+
+$foo = $bar;
+
+#Should not find the rest of these
+
+__DATA__
+
+Fred
+Barney
+Wilma
+
+
+#-----------------------------------------------------------------------------
+
+## name utf8 used OK
+## failures 0
+## cut
+
+use utf8;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name other module included before utf8
+## failures 0
+## cut
+
+use Module;
+use utf8;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name package statement before utf8
+## failures 0
+## cut
+
+package FOO;
+use utf8;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name Work around a PPI bug that doesn't return a location for C<({})>.
+## failures 1
+## cut
+
+({})
+
+#-----------------------------------------------------------------------------
+
+## name Mojolicious::Lite support
+## failures 0
+## cut
+
+use Mojolicious::Lite;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name Dancer2 support
+## failures 0
+## cut
+
+use Dancer2;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name source::encoding 'utf8' support (Perl 5.41+)
+## failures 0
+## cut
+
+use source::encoding 'utf8';
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name source::encoding "utf8" with double quotes
+## failures 0
+## cut
+
+use source::encoding "utf8";
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name source::encoding with ascii (not utf8)
+## failures 1
+## cut
+
+use source::encoding 'ascii';
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name Custom configured equivalent modules
+## failures 0
+## parms { equivalent_modules => 'Foo' }
+## cut
+
+use Foo;
+$foo = $bar;
+
+#-----------------------------------------------------------------------------
+
+## name "use utf8" in lexical context (BEGIN block)
+## failures 1
+## cut
+
+BEGIN{ use utf8 }  # notice this is first statement in file
+$this_is_not_utf8
+
+#-----------------------------------------------------------------------------
+
+## name "use utf8" in lexical context (subroutine)
+## failures 1
+## cut
+
+sub foo { use utf8 }  # notice this is first statement in file
+$this_is_not_utf8
+
+# Local Variables:
+#   mode: cperl
+#   cperl-indent-level: 4
+#   fill-column: 78
+#   indent-tabs-mode: nil
+#   c-indentation-style: bsd
+# End:
+# ex: set ts=8 sts=4 sw=4 tw=78 ft=perl expandtab shiftround :


### PR DESCRIPTION
## Summary

Add a new policy `InputOutput::RequireUseUTF8` that requires the `use utf8` pragma before any code that could contain UTF-8 string literals.

## Code Examples

### ❌ Violation

```perl
use v5.42;
say "🐪"
```

### ✅ OK

```perl
use v5.42;
use utf8;
say "🐪"
```

```perl
use v5.42;
use Mojolicious::Lite;  # Automatically enables utf8
say "🐪"
```

```perl
use v5.42;
use source::encoding 'utf8';  # Perl 5.41+
say "🐪"
```

## Background

This policy was added for the following reasons:

1. **Perl 5.41's source::encoding pragma**: Support for the new `source::encoding` pragma introduced in Perl 5.41
2. **UTF-8 standardization needs**: Teams that handle Unicode characters (emojis, Japanese text, etc.) in source code typically want to enforce `use utf8` in every file

## Features

- Supports `use utf8` pragma
- Supports `use source::encoding 'utf8'` (Perl 5.41+)
- Supports modules that automatically enable utf8: [Dancer](https://metacpan.org/dist/Dancer/source/lib/Dancer.pm#L243), [Dancer2](https://metacpan.org/dist/Dancer2/source/lib/Dancer2.pm#L53), [Mojolicious::Lite](https://metacpan.org/pod/Mojolicious::Lite#SYNOPSIS), [Mojo::Base](https://metacpan.org/pod/Mojo::Base#DESCRIPTION)
- Configurable via `equivalent_modules` parameter in `.perlcriticrc`

## Configuration

- **Category**: InputOutput (for encoding-related policies)
- **Severity**: 4 (SEVERITY_HIGH)
  - No impact on default projects (severity 5)
  - Alerts projects that explicitly set severity to 4
- **Themes**: core bugs

## Note: Diff with RequireUseStrict

This policy is implemented based on `TestingAndDebugging::RequireUseStrict`. The main differences are:

```diff
-package Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict;
+package Perl::Critic::Policy::InputOutput::RequireUseUTF8;

-Readonly::Scalar my $DESC => q{Code before strictures are enabled};
+Readonly::Scalar my $DESC => q{Code before utf8 is enabled};

-            list_always_present_values => ['strict', @STRICT_EQUIVALENT_MODULES],
+            list_always_present_values => ['utf8', @UTF8_EQUIVALENT_MODULES],

-sub default_severity     { return $SEVERITY_HIGHEST   }
-sub default_themes       { return qw( core pbp bugs certrule certrec ) }
+sub default_severity     { return $SEVERITY_HIGH        }
+sub default_themes       { return qw( core bugs )     }
```

**Key differences**:
1. **Severity**: Changed from `SEVERITY_HIGHEST (5)` to `SEVERITY_HIGH (4)`
   - Avoids disrupting default projects
2. **Themes**: Removed `pbp`, `certrule`, `certrec`
   - UTF-8 is not an explicit requirement in PBP or CERT guidelines
3. **source::encoding support**: Added support for Perl 5.41+ feature
4. **Removed use VERSION check**: Unlike strict, there's no Perl version that implies utf8

Full diff can be viewed with:

```bash
diff -u lib/Perl/Critic/Policy/TestingAndDebugging/RequireUseStrict.pm \
        lib/Perl/Critic/Policy/InputOutput/RequireUseUTF8.pm
```
