### PR TITLE
require Module::Pluggable 4.8 in dev

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,8 @@ requires 'Getopt::Long'               => 0;
 requires 'List::SomeUtils'            => '0.55';
 requires 'List::Util'                 => 0;
 requires 'Module::Build'              => '0.4204';
-requires 'Module::Pluggable'          => '3.1';
+# force upgrade to silence deprecation warnings when installing with cpm
+requires 'Module::Pluggable'          => '4.8';
 requires 'PPI'                        => '1.277';
 requires 'PPI::Document'              => '1.277';
 requires 'PPI::Document::File'        => '1.277';


### PR DESCRIPTION
On some older perl versions, Module::Pluggable is included in core but deprecated. It is intended that CPAN clients will always install the CPAN version of the module in this case. CPAN.pm and cpanm do this, but cpm does not.

Add a dependency on a newer version of Module::Pluggable in dev, so the module will always be upgraded and the deprecation warnings will be silenced.